### PR TITLE
Make the tool OS independent

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -1,13 +1,13 @@
 // for crawlers
 exports.axeScript = 'node_modules/axe-core/axe.min.js';
 
-exports.maxRequestsPerCrawl = 100;
+exports.maxRequestsPerCrawl = 1000;
 
 exports.maxConcurrency = 5;
 
 exports.pseudoUrls = host => [
   // eslint-disable-next-line no-useless-escape
-  `[.*(?<!mailto.*)]${host}[(?!.*\.(gif|jpg|jpeg|png|pdf|doc|css|svg|js|ts|xml|csv|tgz|zip|xls|ppt|ico|woff)).*]`,
+  `[.*(?<!mailto.*)]${host}[(?!.*\.(gif|jpg|jpeg|png|webp|avif|pdf|doc|css|svg|js|ts|xml|csv|tgz|zip|xls|ppt|ico|woff)).*]`,
 ];
 
 exports.urlsCrawledObj = {
@@ -38,4 +38,4 @@ exports.impactOrder = {
 };
 
 exports.wcagWebPage = 'https://www.w3.org/TR/WCAG21/';
-exports.axeWebPage = 'https://dequeuniversity.com/rules/axe/3.5/';
+exports.axeWebPage = 'https://dequeuniversity.com/rules/axe/4.3/';

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,8 +293,8 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axe-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.0.tgz",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
       "integrity": "sha512-wJqOIreoFiGjvZ1UZvGLAUs8H3QQ3cS833+6ctFcCdr/xFd5oB66mmwGWnwQlBXFFaefRt+KR+m2dY9em2RxVg=="
     },
     "backo2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,11 +348,6 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
-    "axe-core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
-      "integrity": "sha512-wJqOIreoFiGjvZ1UZvGLAUs8H3QQ3cS833+6ctFcCdr/xFd5oB66mmwGWnwQlBXFFaefRt+KR+m2dY9em2RxVg=="
-    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -1451,6 +1446,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
+    "axe-core": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
+      "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA=="
     },
     "babel-jest": {
       "version": "26.3.0",
@@ -3577,7 +3577,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4136,6 +4137,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6035,6 +6037,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -6049,6 +6052,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -6058,6 +6062,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -6066,13 +6071,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -6081,7 +6088,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7316,7 +7324,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purple-hats",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "apify": "^0.19.1",
-    "axe-core": "^3.5.0",
+    "axe-core": "^4.1.3",
     "fs-extra": "^8.1.0",
     "mustache": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "purple-hats",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "apify": "^0.19.1",
-    "axe-core": "^4.1.3",
+    "axe-core": "^4.3.3",
     "fs-extra": "^8.1.0",
     "mustache": "^4.0.1"
   },

--- a/run.sh
+++ b/run.sh
@@ -102,9 +102,17 @@ then
     currentDate=$(date '+%Y-%-m-%-d')
 
     echo "Scanning website..."
-    
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        xdg-open results/$currentDate/$randomToken/reports/report.html
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        open -a "Google Chrome" results/$currentDate/$randomToken/reports/report.html     
+    else 
+        echo results/$currentDate/$randomToken/reports/report.html 
+    fi
+ 
     URL=$page RANDOMTOKEN=$randomToken TYPE=$crawler node -e 'require("./combine").combineRun()' | tee errors.txt
-    open -a "Google Chrome" results/$currentDate/$randomToken/reports/report.html
+    
 else
     echo "This URL does not exist."
 fi


### PR DESCRIPTION
open -a only works on the Mac.  I think that xdg-open is more flexible.

These patches also upgrade axe-core to the latest release. 