### PR TITLE
Fix failing venv install ansible instead with virtualenv

### DIFF
--- a/installers/mac-installer.sh
+++ b/installers/mac-installer.sh
@@ -21,7 +21,7 @@ deactivate 2>/dev/null;
     # Then use the respective python version to create virtual environment & install Ansible
     if ! [ -z "which python3" ]; then
         echo "Skipping Python3 Installation"
-        python3 -m venv a11y
+        python3 -m virtualenv a11y
         . a11y/bin/activate
         yes | pip3 install ansible
     else


### PR DESCRIPTION
### Environment
- macOS Big Sur 11.6 (20G165)
- XCode Version 13.0 (13A233)

### Issue
On macOS 11.6, installing ansible with `venv` fails with the following module error:

Console log
```
user@users-MacBook-Pro installers % ./mac-installer.sh 
Skipping Python3 Installation
Processing /Users/user/Library/Caches/pip/wheels/fc/0f/16/89c0d34a9e3ad28d23267a4ba486ba6fa8ee3ccb2a202efbd2/ansible-4.6.0-py3-none-any.whl
Processing /Users/user/Library/Caches/pip/wheels/a7/0f/17/e9bde9b8a69f5ca0d458fdc22302f5a149e4fb16c5304c5080/ansible_core-2.11.5-py3-none-any.whl
Collecting PyYAML
  Using cached PyYAML-5.4.1.tar.gz (175 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting cryptography
  Downloading cryptography-35.0.0.tar.gz (559 kB)
     |████████████████████████████████| 559 kB 2.4 MB/s 
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting jinja2
  Using cached Jinja2-3.0.2-py3-none-any.whl (133 kB)
Collecting packaging
  Using cached packaging-21.0-py3-none-any.whl (40 kB)
Collecting resolvelib<0.6.0,>=0.5.3
  Using cached resolvelib-0.5.4-py2.py3-none-any.whl (12 kB)
Collecting cffi>=1.12
  Using cached cffi-1.14.6.tar.gz (475 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.0.1.tar.gz (18 kB)
Collecting pyparsing>=2.0.2
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Collecting pycparser
  Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
Using legacy 'setup.py install' for cffi, since package 'wheel' is not installed.
Using legacy 'setup.py install' for MarkupSafe, since package 'wheel' is not installed.
Building wheels for collected packages: PyYAML, cryptography
  Building wheel for PyYAML (PEP 517) ... done
  Created wheel for PyYAML: filename=PyYAML-5.4.1-cp38-cp38-macosx_10_14_x86_64.whl size=45662 sha256=277de71bd6f3ca3bad8f5776e785246cdc9b376239da819cd74d0636a4e7f0f8
  Stored in directory: /Users/user/Library/Caches/pip/wheels/dd/c5/1d/5d7436173d3efd4a14dcb510eb0b29525ecb6b0e41489e716e
  Building wheel for cryptography (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/user/repos/purple-hats/installers/a11y/bin/python3 /Users/user/repos/purple-hats/installers/a11y/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /var/folders/q7/1cqzfcxs7y352l37c_2058m00000gn/T/tmpxqip_ybd
       cwd: /private/var/folders/q7/1cqzfcxs7y352l37c_2058m00000gn/T/pip-install-7apm8tpl/cryptography
  Complete output (170 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.macosx-10.14-x86_64-3.8
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography
  copying src/cryptography/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  copying src/cryptography/utils.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  copying src/cryptography/__about__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  copying src/cryptography/exceptions.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  copying src/cryptography/fernet.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/_oid.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/oid.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/ocsp.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/general_name.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/extensions.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/name.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/base.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/certificate_transparency.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/x509
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/interfaces.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_serialization.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/cmac.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_asymmetric.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_cipheralgorithm.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/poly1305.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/constant_time.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/keywrap.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hmac.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hashes.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/padding.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings
  copying src/cryptography/hazmat/bindings/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x448.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/backend.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ec.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ciphers.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x509.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/aead.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/encode_asn1.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/rsa.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dh.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/cmac.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/utils.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/poly1305.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed25519.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dsa.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/decode_asn1.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hmac.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed448.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x25519.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hashes.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/backends/openssl
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/scrypt.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/pbkdf2.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/hkdf.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/x963kdf.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/kbkdf.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/concatkdf.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/kdf
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/totp.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/hotp.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs12.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs7.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/ssh.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/base.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/serialization
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/algorithms.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/aead.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/modes.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/base.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x448.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ec.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/rsa.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dh.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/types.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/utils.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed25519.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dsa.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed448.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x25519.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/padding.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/__init__.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/_conditional.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/binding.py -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/openssl
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.coveragerc'
  warning: no previously-included files found matching 'codecov.yml'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files found matching 'mypy.ini'
  warning: no previously-included files matching '*' found under directory '.zuul.d'
  warning: no previously-included files matching '*' found under directory '.zuul.playbooks'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
  copying src/cryptography/py.typed -> build/lib.macosx-10.14-x86_64-3.8/cryptography
  creating build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/__init__.pyi -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/asn1.pyi -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/ocsp.pyi -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/x509.pyi -> build/lib.macosx-10.14-x86_64-3.8/cryptography/hazmat/bindings/_rust
  running build_ext
  generating cffi module 'build/temp.macosx-10.14-x86_64-3.8/_openssl.c'
  creating build/temp.macosx-10.14-x86_64-3.8
  running build_rust
  
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation/ for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq/
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation/#rust
  
      Python: 3.8.9
      platform: macOS-11.6-x86_64-i386-64bit
      pip: n/a
      setuptools: 58.2.0
      setuptools_rust: 0.12.1
      =============================DEBUG ASSISTANCE=============================
  
  error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
  
  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
Successfully built PyYAML
Failed to build cryptography
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 20.2.3; however, version 21.2.4 is available.
You should consider upgrading via the '/Users/user/repos/purple-hats/installers/a11y/bin/python3 -m pip install --upgrade pip' command.
./mac-installer.sh: line 46: ansible-playbook: command not found
mv: rename a11y to ../a11y: Directory not empty
```

## Resolution
Replacing `venv` with `virtualenv` results in installation working again.

Console log
```
user@users-MacBook-Pro installers % ./mac-installer.sh
Skipping Ansible install
./mac-installer.sh: line 46: ansible-playbook: command not found
mv: rename a11y to ../a11y: Directory not empty
user@users-MacBook-Pro installers % rm -rf a11y 
user@users-MacBook-Pro installers % ./mac-installer.sh
Skipping Python3 Installation
created virtual environment CPython3.8.9.final.0-64 in 2004ms
  creator CPython3macOsFramework(dest=/Users/user/repos/purple-hats/installers/a11y, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/user/Library/Application Support/virtualenv)
    added seed packages: pip==21.2.4, setuptools==58.1.0, wheel==0.37.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Collecting ansible
  Using cached ansible-4.6.0-py3-none-any.whl
Collecting ansible-core<2.12,>=2.11.5
  Using cached ansible_core-2.11.5-py3-none-any.whl
Collecting resolvelib<0.6.0,>=0.5.3
  Using cached resolvelib-0.5.4-py2.py3-none-any.whl (12 kB)
Collecting PyYAML
  Using cached PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl (253 kB)
Collecting cryptography
  Using cached cryptography-35.0.0-cp36-abi3-macosx_10_10_x86_64.whl (2.5 MB)
Collecting packaging
  Using cached packaging-21.0-py3-none-any.whl (40 kB)
Collecting jinja2
  Using cached Jinja2-3.0.2-py3-none-any.whl (133 kB)
Collecting cffi>=1.12
  Using cached cffi-1.14.6-cp38-cp38-macosx_10_9_x86_64.whl (176 kB)
Collecting pycparser
  Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl (13 kB)
Collecting pyparsing>=2.0.2
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Installing collected packages: pycparser, pyparsing, MarkupSafe, cffi, resolvelib, PyYAML, packaging, jinja2, cryptography, ansible-core, ansible
Successfully installed MarkupSafe-2.0.1 PyYAML-5.4.1 ansible-4.6.0 ansible-core-2.11.5 cffi-1.14.6 cryptography-35.0.0 jinja2-3.0.2 packaging-21.0 pycparser-2.20 pyparsing-2.4.7 resolvelib-0.5.4

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: Platform darwin on host localhost is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.11/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [Debian-based OS] *********************************************************
skipping: [localhost]

TASK [Install npm] *************************************************************
skipping: [localhost]

TASK [Check version of npm] ****************************************************
skipping: [localhost]

TASK [Install packages based on package.json using the npm] ********************
skipping: [localhost]

TASK [Non Debian-based OS] *****************************************************
ok: [localhost] => {
    "msg": "Install npm via nvm"
}

TASK [Get nvm.sh] **************************************************************
changed: [localhost]

TASK [Create $PWD/.nvm directory] **********************************************
changed: [localhost]

TASK [Install nvm] *************************************************************
changed: [localhost]

TASK [Install and Use Node.js {{ node_js_version }}] ***************************
changed: [localhost]

TASK [Save location of npm] ****************************************************
ok: [localhost]

TASK [Set npm location into path of ansible environment] ***********************
ok: [localhost] => {
    "msg": "/Users/user/repos/purple-hats/installers/ansible/.nvm/versions/node/v13.5.0/bin/npm:/Users/user/repos/purple-hats/installers/a11y/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin"
}

TASK [Save location of npm] ****************************************************
ok: [localhost]

TASK [Install packages based on package.json using the npm installed with nvm v0.35.2.] ***
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=10   changed=5    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   

mv: rename a11y to ../a11y: Directory not empty
```