### PR TITLE
Remove check for domain match when sitemap scan

### DIFF
--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -25,17 +25,14 @@ exports.crawlSitemap = async (sitemapUrl, randomToken, host) => {
     handlePageFunction: async ({ page, request }) => {
       const currentUrl = request.url;
       const location = await page.evaluate('location');
-      if (location.host.includes(host)) {
-        if (validateUrl(currentUrl)) {
-          const results = await runAxeScript(page, host);
-          await dataset.pushData(results);
-          urlsCrawled.scanned.push(currentUrl);
-        } else {
-          urlsCrawled.invalid.push(currentUrl);
-        }
+      if (validateUrl(currentUrl)) {
+        const results = await runAxeScript(page, host);
+        await dataset.pushData(results);
+        urlsCrawled.scanned.push(currentUrl);
       } else {
-        urlsCrawled.outOfDomain.push(currentUrl);
+        urlsCrawled.invalid.push(currentUrl);
       }
+
     },
     handleFailedRequestFunction,
     maxRequestsPerCrawl,


### PR DESCRIPTION
In certain usage scenarios, Purple hats will skip scanning sitemap.xml hosted in a different domain as the URL listed in `<loc>` of sitemap.  

Removing the domain check funcionality allows sitemap.xml from a different host as the pages located in sitemap.