### PR TITLE
Improve CLI integration with switch options for scan output

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,33 @@ If the website URL provided is invalid, an error message will be prompted for yo
 ### CLI Mode
 CLI mode is designed to be run in continuous integration (CI) environment.  Run `node cli.js` for a set of command-line parameters available.  Please note CLI mode is only supported on Mac/Linux at this moment.
 
+```shell
+Usage: node cli.js -c <crawler> -u <url> OPTIONS
+
+Options:
+      --help             Show help                                     [boolean]
+      --version          Show version number                           [boolean]
+  -c, --scanner          Type of crawler, 1) sitemap or 2) website
+                                      [required] [choices: "sitemap", "website"]
+  -u, --url              Website URL you want to scan        [string] [required]
+  -o, --zip              Zip filename to save results                   [string]
+      --reportbreakdown  Will break down the main report according to impact
+                                                      [boolean] [default: false]
+      --warn             Track for issues of target impact level
+         [choices: "critical", "serious", "moderate", "minor", "none"] [default:
+                                                                         "none"]
+
+Examples:
+  To scan sitemap of website:', 'node cli.js -c [ 1 | sitemap ] -u <url_link>
+  To scan a website', 'node cli.js -c [ 2 | website ] -u <url_link>
+
+Missing required arguments: c, u
+```
+
+For example, to conduct a website scan to the URL `http://localhost:8000` and write to `a11y-scan-results.zip`, run
+```shell
+node cli.js -c 2 -o a11y-scan-results.zip -u http://localhost:8000
+```
 
 ## Troubleshooting
 Please refer to the information below to exist in debugging. Most errors below are due to the switching between Node.js versions.

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const {
 } = require('./utils');
 const { checkUrl, prepareData, isSelectorValid, isInputValid } = require('./constants/common');
 const {
-  bambooOptions,
+  cliOptions,
   messageOptions,
   configureReportSetting,
 } = require('./constants/cliFunctions');
@@ -33,7 +33,7 @@ cleanUp('apify_storage');
 const options = yargs
   .usage('Usage: node cli.js -c <crawler> -u <url> OPTIONS')
   .strictOptions(true)
-  .options(bambooOptions)
+  .options(cliOptions)
   .example([
     [`To scan sitemap of website:', 'node cli.js -c [ 1 | ${scannerTypes.sitemap} ] -u <url_link>`],
     [`To scan a website', 'node cli.js -c [ 2 | ${scannerTypes.website} ] -u <url_link>`]

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,11 @@ const {
   messageOptions,
   configureReportSetting,
 } = require('./constants/cliFunctions');
-const { scannerTypes } = require('./constants/constants');
+const { 
+  scannerTypes,
+  cliZipFileName,
+} = require('./constants/constants');
+
 const { consoleLogger } = require('./logs');
 const { combineRun } = require('./combine');
 
@@ -91,15 +95,13 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async () => {
   const storagePath = getStoragePath(randomToken);
-  const reportPath = `${storagePath}/reports`;
-  const finalPath = `${reportPath}/${randomToken}.zip`;
 
   await fs
-    .ensureDir(reportPath)
+    .ensureDir(storagePath)
     .then(async () => {
-      await zipResults(finalPath, reportPath);
+      await zipResults(cliZipFileName, storagePath);
       const messageToDisplay = [
-        `Report of this run is ${randomToken}.zip under ${reportPath}.`,
+        `Report of this run is at ${cliZipFileName}`,
       ];
 
       if (process.env.REPORT_BREAKDOWN === '1') {

--- a/cli.js
+++ b/cli.js
@@ -18,8 +18,12 @@ const {
   messageOptions,
   configureReportSetting,
 } = require('./constants/cliFunctions');
+
 const { 
   scannerTypes,
+} = require('./constants/constants');
+
+let { 
   cliZipFileName,
 } = require('./constants/constants');
 
@@ -94,7 +98,13 @@ const scanInit = async argvs => {
 };
 
 scanInit(options).then(async () => {
+  // Path to scan result
   const storagePath = getStoragePath(randomToken);
+
+  // Take option if set
+  if (typeof options.zip === 'string') {
+    cliZipFileName = options.zip;
+  }
 
   await fs
     .ensureDir(storagePath)

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -22,6 +22,12 @@ exports.cliOptions = {
     type: 'string',
     demandOption: true,
   },
+  o: {
+    alias: 'zip',
+    describe: 'Zip filename to save results',
+    type: 'string',
+    demandOption: false,
+  },
   reportbreakdown: {
     describe: 'Will break down the main report according to impact',
     type: 'boolean',

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -9,7 +9,7 @@ exports.alertMessageOptions = {
   borderColor: 'red',
 };
 
-exports.bambooOptions = {
+exports.cliOptions = {
   c: {
     alias: 'scanner',
     describe: 'Type of crawler, 1) sitemap or 2) website',

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -30,6 +30,8 @@ exports.a11yDataStoragePath = `${a11yStorage}/datasets`;
 
 exports.allIssueFileName = 'all_issues';
 
+exports.cliZipFileName = 'a11y-scan-results.zip';
+
 exports.rootPath = __dirname;
 
 // others

--- a/utils.js
+++ b/utils.js
@@ -109,6 +109,11 @@ exports.zipResults = async (zipName, resultsPath) => {
   // eslint-disable-next-line global-require
   const { execFile } = require('child_process');
 
+  // Validate Zip filename
+  const zipFilenamePattern = /^(?!^(PRN|AUX|CLOCK\$|NUL|CON|COM\d|LPT\d|\..*)(\..+)?$)[^\x00-\x1f\\?*:\";|/]+\.zipx*$/;
+  if (!zipFilenamePattern.test(zipName)) {
+  }
+
   // Check prior zip file exist and remove
   if (fs.existsSync(zipName)) {
     fs.unlink(zipName);  

--- a/utils.js
+++ b/utils.js
@@ -108,12 +108,7 @@ exports.setThresholdLimits = setWarnLevel => {
 exports.zipResults = async (zipName, resultsPath) => {
   // eslint-disable-next-line global-require
   const { execFile } = require('child_process');
-
-  // Validate Zip filename
-  if (!(/^[a-z0-9_.@()-]+\.zip$/.test(zipName))) {
-    throw "Invalid filename " + zipName;
-  }
-
+  
   // Check prior zip file exist and remove
   if (fs.existsSync(zipName)) {
     fs.unlink(zipName);  

--- a/utils.js
+++ b/utils.js
@@ -110,9 +110,7 @@ exports.zipResults = async (zipName, resultsPath) => {
   const { execFile } = require('child_process');
 
   // Validate Zip filename
-  const zipFilenamePattern = /^[a-z0-9_.@()-]+\.zip$/;
-
-  if (!zipFilenamePattern.test(zipName)) {
+  if (!(/^[a-z0-9_.@()-]+\.zip$/.test(zipName))) {
     throw "Invalid filename " + zipName;
   }
 

--- a/utils.js
+++ b/utils.js
@@ -110,8 +110,10 @@ exports.zipResults = async (zipName, resultsPath) => {
   const { execFile } = require('child_process');
 
   // Validate Zip filename
-  const zipFilenamePattern = /^(?!^(PRN|AUX|CLOCK\$|NUL|CON|COM\d|LPT\d|\..*)(\..+)?$)[^\x00-\x1f\\?*:\";|/]+\.zipx*$/;
+  const zipFilenamePattern = /^[a-z0-9_.@()-]+\.zip$/;
+
   if (!zipFilenamePattern.test(zipName)) {
+    throw "Invalid filename " + zipName;
   }
 
   // Check prior zip file exist and remove

--- a/utils.js
+++ b/utils.js
@@ -109,6 +109,11 @@ exports.zipResults = async (zipName, resultsPath) => {
   // eslint-disable-next-line global-require
   const { execFile } = require('child_process');
 
+  // Check prior zip file exist and remove
+  if (fs.existsSync(zipName)) {
+    fs.unlink(zipName);  
+  }
+
   // To zip up files recursively )-r) in the results folder path
   // Will only zip up the content of the results folder path with (-j) i.e. junk the path
   const command = '/usr/bin/zip';


### PR DESCRIPTION
* Option to save to a custom zip filename with `-o filename.zip` switch
* Set default filename of output zip as `a11y-scan-results.zip`
* Update README.md with CLI scan example