### PR TITLE
Upgrade from Apify 2.3.2 to Crawlee 3.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Purple HATS is a customisable, automated accessibility testing tool that allows software development teams to assess whether their products are user-friendly to persons with disabilities (PWDs).
 
 ## Technology Stack
-1. [Apify SDK](https://sdk.apify.com/)
+1. [Crawlee](https://crawlee.dev/)
 2. [Axe-core](https://github.com/dequelabs/axe-core)
 3. [Node.js](https://Node.js.org/en/)
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -93,21 +93,21 @@ describe('test getStoragePath', () => {
 describe('test setHeadlessMode', () => {
   test('should headlessMode is true', () => {
     setHeadlessMode(true);
-    expect(process.env.APIFY_HEADLESS).toEqual('1');
+    expect(process.env.CRAWLEE_HEADLESS).toEqual('1');
   });
   test('should headlessMode is false', () => {
     setHeadlessMode(false);
-    expect(process.env.APIFY_HEADLESS).toEqual('0');
+    expect(process.env.CRAWLEE_HEADLESS).toEqual('0');
   });
 });
 
 describe('test setHeadlessMode', () => {
   test('should headlessMode is true', () => {
     setHeadlessMode(true);
-    expect(process.env.APIFY_HEADLESS).toEqual('1');
+    expect(process.env.CRAWLEE_HEADLESS).toEqual('1');
   });
   test('should headlessMode is false', () => {
     setHeadlessMode(false);
-    expect(process.env.APIFY_HEADLESS).toEqual('0');
+    expect(process.env.CRAWLEE_HEADLESS).toEqual('0');
   });
 });

--- a/combine.js
+++ b/combine.js
@@ -5,7 +5,7 @@ const { generateArtifacts } = require('./mergeAxeResults');
 const { getHostnameFromRegex, createAndUpdateFolders } = require('./utils');
 const { a11yStorage, scannerTypes } = require('./constants/constants');
 
-process.env.APIFY_LOCAL_STORAGE_DIR = a11yStorage;
+process.env.CRAWLEE_STORAGE_DIR = a11yStorage;
 
 exports.combineRun = async details => {
   const envDetails = { ...details };

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -5,11 +5,6 @@ exports.maxRequestsPerCrawl = 100;
 
 exports.maxConcurrency = 5;
 
-exports.pseudoUrls = host => [
-  // eslint-disable-next-line no-useless-escape
-  `[.*(?<!mailto.*)]${host}[(?!.*\.(gif|jpg|jpeg|png|pdf|doc|css|svg|js|ts|xml|csv|tgz|zip|xls|ppt|ico|woff)).*]`,
-];
-
 exports.urlsCrawledObj = {
   scanned: [],
   invalid: [],

--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
-const Apify = require('apify');
+const crawlee = require('crawlee');
 const axe = require('axe-core');
 const { axeScript } = require('../constants/constants');
 
@@ -29,7 +29,7 @@ const filterAxeResults = (results, host) => {
 };
 
 exports.runAxeScript = async (page, host) => {
-  await Apify.utils.puppeteer.injectFile(page, axeScript);
+  await crawlee.puppeteerUtils.injectFile(page, axeScript);
   const results = await page.evaluate(() => {
     axe.configure({
       branding: {
@@ -44,9 +44,9 @@ exports.runAxeScript = async (page, host) => {
   return filterAxeResults(results, host);
 };
 
-exports.createApifySubFolders = async randomToken => {
-  const dataset = await Apify.openDataset(randomToken);
-  const requestQueue = await Apify.openRequestQueue(randomToken);
+exports.createCrawleeSubFolders = async randomToken => {
+  const dataset = await crawlee.Dataset.open(randomToken);
+  const requestQueue = await crawlee.RequestQueue.open(randomToken);
   return { dataset, requestQueue };
 };
 
@@ -56,6 +56,6 @@ exports.preNavigationHooks = [
   },
 ];
 
-exports.handleFailedRequestFunction = async ({ request }) => {
-  Apify.utils.log.error(`Failed Request - ${request.url}: ${request.errorMessages}`);
+exports.failedRequestHandler = async ({ request }) => {
+  crawlee.log.error(`Failed Request - ${request.url}: ${request.errorMessages}`);
 };

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -1,28 +1,27 @@
-const Apify = require('apify');
+const crawlee = require('crawlee');
 const {
-  createApifySubFolders,
+  createCrawleeSubFolders,
   preNavigationHooks,
   runAxeScript,
-  handleFailedRequestFunction,
+  failedRequestHandler,
 } = require('./commonCrawlerFunc');
 const {
   maxRequestsPerCrawl,
   maxConcurrency,
-  pseudoUrls,
   urlsCrawledObj,
 } = require('../constants/constants');
 
 exports.crawlDomain = async (url, randomToken, host) => {
   const urlsCrawled = { ...urlsCrawledObj };
 
-  const { dataset, requestQueue } = await createApifySubFolders(randomToken);
+  const { dataset, requestQueue } = await createCrawleeSubFolders(randomToken);
 
   await requestQueue.addRequest({ url });
 
-  const crawler = new Apify.PuppeteerCrawler({
+  const crawler = new crawlee.PuppeteerCrawler({
     requestQueue,
     preNavigationHooks,
-    handlePageFunction: async ({ page, request }) => {
+    requestHandler: async ({ page, request, enqueueLinks }) => {
       const currentUrl = request.url;
       const location = await page.evaluate('location');
       if (location.host.includes(host)) {
@@ -30,17 +29,16 @@ exports.crawlDomain = async (url, randomToken, host) => {
         await dataset.pushData(results);
         urlsCrawled.scanned.push(currentUrl);
 
-        await Apify.utils.enqueueLinks({
-          page,
+        await enqueueLinks({
           selector: 'a',
-          pseudoUrls: pseudoUrls(host),
+          strategy: 'same-domain',
           requestQueue,
         });
       } else {
         urlsCrawled.outOfDomain.push(currentUrl);
       }
     },
-    handleFailedRequestFunction,
+    failedRequestHandler,
     maxRequestsPerCrawl,
     maxConcurrency,
   });

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -1,9 +1,9 @@
-const Apify = require('apify');
+const crawlee = require('crawlee');
 const {
-  createApifySubFolders,
+  createCrawleeSubFolders,
   preNavigationHooks,
   runAxeScript,
-  handleFailedRequestFunction,
+  failedRequestHandler,
 } = require('./commonCrawlerFunc');
 const { validateUrl } = require('../utils');
 const { maxRequestsPerCrawl, maxConcurrency, urlsCrawledObj } = require('../constants/constants');
@@ -11,18 +11,18 @@ const { maxRequestsPerCrawl, maxConcurrency, urlsCrawledObj } = require('../cons
 exports.crawlSitemap = async (sitemapUrl, randomToken, host) => {
   const urlsCrawled = { ...urlsCrawledObj };
 
-  const requestList = new Apify.RequestList({
+  const requestList = new crawlee.RequestList({
     sources: [{ requestsFromUrl: sitemapUrl }],
   });
   await requestList.initialize();
 
-  const { dataset, requestQueue } = await createApifySubFolders(randomToken);
+  const { dataset, requestQueue } = await createCrawleeSubFolders(randomToken);
 
-  const crawler = new Apify.PuppeteerCrawler({
+  const crawler = new crawlee.PuppeteerCrawler({
     requestList,
     requestQueue,
     preNavigationHooks,
-    handlePageFunction: async ({ page, request }) => {
+    requestHandler: async ({ page, request }) => {
       const currentUrl = request.url;
       const location = await page.evaluate('location');
       if (validateUrl(currentUrl)) {
@@ -34,7 +34,7 @@ exports.crawlSitemap = async (sitemapUrl, randomToken, host) => {
       }
 
     },
-    handleFailedRequestFunction,
+    failedRequestHandler,
     maxRequestsPerCrawl,
     maxConcurrency,
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "apify": "^2.3.2",
         "axe-core": "^4.4.1",
         "axios": "^0.25.0",
+        "crawlee": "^3.1.4",
         "fs-extra": "^10.0.0",
         "inquirer": "^8.2.0",
         "jsdom": "^19.0.0",
@@ -47,21 +47,21 @@
       }
     },
     "node_modules/@apify/consts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.3.0.tgz",
-      "integrity": "sha512-9SkEA9aOy+hqE3ayA9aHnoVTFYYEDn41Q9EjU4sVSaCrxHLp9MQqdiGYQnXrmmCtbxbj/pJeb6MLxnACI5e/yg=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.8.0.tgz",
+      "integrity": "sha512-uQBRggMka8HtpkLWJeA9ZITDxgAgpwDoL1Uj8QXGaZDj0Rb7Z7YcEAJ8KNRoj0yuIlqoS6NwNWEwfpFIjSYt3Q=="
     },
     "node_modules/@apify/datastructures": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-1.0.1.tgz",
-      "integrity": "sha512-AgnrfMjzDph+Te5WGNnIsz3+dJM7v/Sqo82nWwSqca292paRotUhORXr9Ik+d0yurC5LutDAhcvu8VZ8SfANGg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.0.tgz",
+      "integrity": "sha512-O7I31PvG4Qb/Zc2lAIkSUBRDLKDKLrmqtWG3Ea8To5xvbPKdiLuVx3IuAzjCs1UQVTbhN590Sw5xBoFghreAYA=="
     },
     "node_modules/@apify/log": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.1.3.tgz",
-      "integrity": "sha512-HhL7zZJecFzYNxdbLS8OttixvShZRbzW6UAms/oKAGuFn1O/L+AWy6jk8zrTbg7QY9lPk9FfdXM3OO+vza6mSw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.2.5.tgz",
+      "integrity": "sha512-wJPIytLWy3iVjFaJUHH6FvtyoSiLFeArjbVJ9xFzQ+lFeHxPLTMIgC2H/6EknP7T/n/7v0SkbSmsbHNtsPGnEQ==",
       "dependencies": {
-        "@apify/consts": "^2.3.0",
+        "@apify/consts": "^2.8.0",
         "ansi-colors": "^4.1.1"
       }
     },
@@ -79,64 +79,27 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/@apify/storage-local": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.1.0.tgz",
-      "integrity": "sha512-oKz+fYJ6IsaOH4JQpfq3DSpOhKHd3muMuqd50dv8QV68ia9goFFnc804rb6yaPvNIcGbp8xREPqu0VMFy2iEjg==",
+    "node_modules/@apify/pseudo_url": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.11.tgz",
+      "integrity": "sha512-tjPHT/8bqU7dvyW9TMT1pAMNKRJ5Upg1pN2EQqDNuD/hp6aUFLmsN4X1IQugyAy5hLqzgk81XQJ6lgKiwWjgHQ==",
       "dependencies": {
-        "@apify/consts": "^1.10.0",
-        "@apify/log": "^1.2.3",
-        "better-sqlite3-with-prebuilds": "^7.4.3",
-        "content-type": "^1.0.4",
-        "fs-extra": "^10.1.0",
-        "mime-types": "^2.1.35",
-        "ow": "^0.28.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@apify/storage-local/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/@apify/storage-local/node_modules/@apify/log": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-      "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-      "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "ansi-colors": "^4.1.1"
+        "@apify/log": "^2.2.5",
+        "@sapphire/shapeshift": "^3.6.0"
       }
     },
     "node_modules/@apify/timeout": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.2.1.tgz",
-      "integrity": "sha512-487pqjk6OZXcTeAJlby7Kwu65d2dLl/LMcVqUXjcCoRvfGn3hRMAkd0GHHWuJzknY4Zh8pKM9qtj5AS3fPKEQw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.0.tgz",
+      "integrity": "sha512-jLwg4vC1hHsU1UWbwO5suYFGPBANPy5Dovc6P9y56TZ1B2RsRYjfDaX3BdfaAa6E2akib19EinF9EjuN13m5AA=="
     },
     "node_modules/@apify/utilities": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-1.2.14.tgz",
-      "integrity": "sha512-UejFdqZrK1DIxApxS0GQDISpd68wCz++1Bh/JEw8qD7ZxWA6P5Huh5smIv8bSTRXzUbFhobpIVie/2OMIrM30A==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.2.7.tgz",
+      "integrity": "sha512-uHwndKAgwRvj5ovWo9cdut5oBJVwcl1qWCP7Dj9zQkXOezbTTtRYIki7DkeUC3PFIP/R8yn9l7BMsLizelFe2w==",
       "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "@apify/log": "^1.2.5"
-      }
-    },
-    "node_modules/@apify/utilities/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/@apify/utilities/node_modules/@apify/log": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-      "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-      "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "ansi-colors": "^4.1.1"
+        "@apify/consts": "^2.8.0",
+        "@apify/log": "^2.2.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -618,6 +581,874 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@crawlee/basic": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.1.4.tgz",
+      "integrity": "sha512-8ON2ZOMERpzQ1WZ7D+aFfD1OnpOsrrf2U6cnYX62u+/XIuchEpjbfCCoX1A39Xq8ZwlkJJSUCp2kbqGZDhsHww==",
+      "dependencies": {
+        "@apify/log": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/core": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "got-scraping": "^3.2.9",
+        "ow": "^0.28.1",
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/basic/node_modules/type-fest": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+      "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/browser": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.1.4.tgz",
+      "integrity": "sha512-7cS+c5WPgK9DKNr0JHeRmJwOGHFBguISrkgTLe/9JyAjK8zcvBHZBWrzvpfZfdVsFcsn61typPCfefs+mxcGbg==",
+      "dependencies": {
+        "@apify/timeout": "^0.3.0",
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "ow": "^0.28.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/browser-pool": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.1.3.tgz",
+      "integrity": "sha512-0eZj87zw4FiH5WkUQnXZ+tbFq4JaTYmPHYd8NruLKKtewto0HYMuuiVLkhfrm+YR93PkZt3SQuErkek+s1vXLw==",
+      "dependencies": {
+        "@apify/log": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@crawlee/types": "^3.1.2",
+        "fingerprint-generator": "^2.0.6",
+        "fingerprint-injector": "^2.0.5",
+        "lodash.merge": "^4.6.2",
+        "nanoid": "^3.3.4",
+        "ow": "^0.28.1",
+        "p-limit": "^3.1.0",
+        "proxy-chain": "^2.0.1",
+        "quick-lru": "^5.1.1",
+        "tiny-typed-emitter": "^2.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "playwright": ">= 1.21.x <= 1.27.x",
+        "puppeteer": "<= 19.x"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@crawlee/browser-pool/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/cheerio": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.1.4.tgz",
+      "integrity": "sha512-rkkX1aqewU2qI4QxCduTIcgjE6IijaE01ShYf9mUQBOQRCg5bl2ktk0cSuNvx3DSkjEsZkfEfanQMMLV2/WfBA==",
+      "dependencies": {
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "htmlparser2": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/cli": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.1.2.tgz",
+      "integrity": "sha512-NPhZ4KUyb04vq9n5uLYFy9iTQlbNg/+87MnKJ1fFNdUN/dFrBR01zcL7r2IcJqzPaRrRp9cWJwQ4kcXbeDfqOg==",
+      "dependencies": {
+        "@crawlee/templates": "^3.1.2",
+        "ansi-colors": "^4.1.3",
+        "fs-extra": "^10.1.0",
+        "inquirer": "^8.2.4",
+        "yargonaut": "^1.1.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "crawlee": "index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@crawlee/cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/inquirer": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@crawlee/cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@crawlee/core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.1.3.tgz",
+      "integrity": "sha512-aiI3m4jBF70Jiq1oD7xjqE9QW1eUHftyB3oANXtvIIbnUyxkP63IEhAe096TgEyPeOfnNGFOOEUNbI5OmwKOpw==",
+      "dependencies": {
+        "@apify/consts": "^2.0.0",
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@apify/pseudo_url": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/memory-storage": "^3.1.2",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "@types/tough-cookie": "^4.0.2",
+        "@vladfrangu/async_event_emitter": "^2.0.0",
+        "csv-stringify": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "json5": "^2.2.1",
+        "minimatch": "^5.1.0",
+        "ow": "^0.28.1",
+        "stream-chain": "^2.2.5",
+        "stream-json": "^1.7.4",
+        "tldts": "^5.7.80",
+        "tough-cookie": "^4.0.0",
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@crawlee/core/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@crawlee/core/node_modules/type-fest": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+      "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/http": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.1.4.tgz",
+      "integrity": "sha512-DEpIWTTmc0MpbIAzIRkIoMHOJOS4hG4BCjq/WFlJcB/sm4VreghUWxOMFOg5U3vndiHeN6aqIPMKX8rnI2Ig4Q==",
+      "dependencies": {
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "@types/content-type": "^1.1.5",
+        "content-type": "^1.0.4",
+        "got-scraping": "^3.2.9",
+        "iconv-lite": "^0.6.3",
+        "mime-types": "^2.1.35",
+        "ow": "^0.28.1",
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/http/node_modules/type-fest": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+      "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/jsdom": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.1.4.tgz",
+      "integrity": "sha512-Ni/gV1WmI+ikpL8jAo7yAsfm7sRaIHTRQd/Z5jyjm8BcC9aUNMOQRTlDCAnNLLVVAic9gZpJfxzojsK55Dhjzw==",
+      "dependencies": {
+        "@apify/utilities": "^2.1.4",
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "@types/jsdom": "^20.0.0",
+        "jsdom": "^20.0.0",
+        "ow": "^0.28.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@crawlee/jsdom/node_modules/ws": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@crawlee/memory-storage": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.1.2.tgz",
+      "integrity": "sha512-+ciFZmwhrIUmshUx+rx5CBRZ7nOT8K7I0jWp5QrSKBNFnpvR/PW89QjR8cWAUHRz69p7kicMrgXUroGzgZ9h7w==",
+      "dependencies": {
+        "@apify/log": "^2.0.0",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "@sapphire/shapeshift": "^3.0.0",
+        "content-type": "^1.0.4",
+        "fs-extra": "^10.1.0",
+        "json5": "^2.2.1",
+        "mime-types": "^2.1.35",
+        "proper-lockfile": "^4.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@crawlee/playwright": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.1.4.tgz",
+      "integrity": "sha512-sVO0neH7lVM3BYEoGVm1iv99M9yaI52Om4QCNJSJ0SdFdpeABM3Lpm/K/sLzoAai70y/VFlY+ofXL5hIVLPKBA==",
+      "dependencies": {
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "jquery": "^3.6.0",
+        "ow": "^0.28.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "playwright": ">= 1.21.x <= 1.27.x"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@crawlee/puppeteer": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.1.4.tgz",
+      "integrity": "sha512-rSqALBbsmVfzQ0UsfLXuO4DEKhhTHm8BIzyNQWIAi0FxeW1CGUmwM63UM9jGSwRcZT4BcJETTqu+unwci9/yNQ==",
+      "dependencies": {
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "devtools-protocol": "*",
+        "jquery": "^3.6.0",
+        "ow": "^0.28.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "puppeteer": "<= 19.x"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@crawlee/templates": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.1.2.tgz",
+      "integrity": "sha512-ubhcg8C+Vk2kN4V7VvWh9B/9VOmN8jS56ePN1/VH4+faiaRxuMv4zftRXXXyVxbcDyhMM0BLyVIxNLt6iAY1iA==",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "inquirer": "^9.0.0",
+        "yargonaut": "^1.1.4",
+        "yargs": "^17.5.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/ansi-escapes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.0.0.tgz",
+      "integrity": "sha512-IG23inYII3dWlU2EyiAiGj6Bwal5GzsgPMwjYGvc1HPE2dgbj4ZB5ToWBKSquKw74nB3TIuOwaI6/jSULzfgrw==",
+      "dependencies": {
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/cli-width": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
+      "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/@crawlee/templates/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/inquirer": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.4.tgz",
+      "integrity": "sha512-9hiJxE5gkK/cM2d1mTEnuurGTAoHebbkX0BYl3h7iEg7FYfuNIom+nDfBCSWtvSnoSrWCeBxqqBZu26xdlJlXA==",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^5.1.2",
+        "cli-cursor": "^4.0.0",
+        "cli-width": "^4.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^5.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^6.1.2",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.7",
+        "string-width": "^5.1.2",
+        "strip-ansi": "^7.0.1",
+        "through": "^2.3.6",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/ora": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+      "dependencies": {
+        "bl": "^5.0.0",
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/type-fest": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+      "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@crawlee/templates/node_modules/wrap-ansi": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/types": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.1.2.tgz",
+      "integrity": "sha512-DNT8slBUpmBJ/bwz2BVs/PRKbpczOuO45G2+hkRFHXZKJSG6HnJgqbZBPzIMtsTJ7Ztxg4xxv2wxiGNPFM25/Q==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@crawlee/utils": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-an8JUVQkmN+9NpTjwTtQOBBgfgK3id2quZHnIXLsFy9RE5lKBQmDZ7Q+AR2Qpndsnpm2WikTQrnvnFiDPYL8bg==",
+      "dependencies": {
+        "@apify/log": "^2.0.0",
+        "@apify/ps-tree": "^1.1.4",
+        "@crawlee/types": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "got-scraping": "^3.2.9",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.2",
@@ -1363,10 +2194,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "engines": {
         "node": ">=10"
       },
@@ -1452,16 +2296,10 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
+    "node_modules/@types/content-type": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.5.tgz",
+      "integrity": "sha512-dgMN+syt1xb7Hk8LU6AODOfPlvz5z1CbXpPuJE5ZrX9STfBOIXF09pEB8N7a97WT9dbngt3ksDCm6GW6yMrxfQ=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -1471,16 +2309,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
-    },
-    "node_modules/@types/integer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/integer/-/integer-4.0.1.tgz",
-      "integrity": "sha512-QQojPymFcV1hrvWXA1h0pP9RmFBFNuWikZcUEjjVsS19IyKO+jqOX24lp2ZHF4A21EmkosJhJDX7CLG67F2s7A=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -1506,24 +2334,32 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ=="
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "16.10.3",
@@ -1550,6 +2386,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -1574,10 +2415,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.1.3.tgz",
+      "integrity": "sha512-o09Pcdu8T9eL9iWcVWuJQnHLvQMYqMNaR5E2PD80A+uuL/u3CR6j0pCmaP1ILVspdAN7yeLnoyo8wljMXArj7Q==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/abab": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -1616,6 +2466,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1625,19 +2483,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1711,172 +2556,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/apify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/apify/-/apify-2.3.2.tgz",
-      "integrity": "sha512-C60Wp6vav6yBhl9OPPiMPpYNKcxi2OmKHppdeNWzlJF6MNreh4MYDqwD8kb2D8f95Yl1cvv8zHJchRBDexdzSw==",
-      "dependencies": {
-        "@apify/consts": "^1.7.0",
-        "@apify/datastructures": "^1.0.1",
-        "@apify/log": "^1.2.0",
-        "@apify/ps-tree": "^1.1.4",
-        "@apify/storage-local": "^2.0.2",
-        "@apify/timeout": "^0.2.1",
-        "@apify/utilities": "^1.2.8",
-        "apify-client": "^2.3.1",
-        "browser-pool": "^3.1.3",
-        "cheerio": "1.0.0-rc.10",
-        "content-type": "^1.0.4",
-        "got-scraping": "^3.2.9",
-        "htmlparser2": "^7.0.0",
-        "iconv-lite": "^0.6.3",
-        "jquery": "^3.6.0",
-        "mime-types": "^2.1.35",
-        "ow": "^0.28.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "stream-json": "^1.7.4",
-        "tough-cookie": "^4.0.0",
-        "underscore": "^1.13.3",
-        "ws": "^7.5.7"
-      },
-      "engines": {
-        "node": ">=15.10.0"
-      },
-      "peerDependencies": {
-        "playwright": "^1.11.0",
-        "puppeteer": ">= 9.x <= 13.x"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        },
-        "puppeteer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/apify-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.6.0.tgz",
-      "integrity": "sha512-qbMfwx/765MT7rh5aqBy5xrj0howOibCrAEIQpWD7zqa4fCpKfGk/8z+MkEXBsgoWNWLR0wRl5/CCTmSjH6+Jw==",
-      "dependencies": {
-        "@apify/consts": "^1.4.0",
-        "@apify/log": "^2.1.0",
-        "agentkeepalive": "^4.1.4",
-        "async-retry": "^1.3.1",
-        "axios": "^0.21.1",
-        "content-type": "^1.0.4",
-        "ow": "^0.27.0"
-      }
-    },
-    "node_modules/apify-client/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/apify-client/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/apify-client/node_modules/ow": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.1",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.1",
-        "vali-date": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/apify-client/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/apify/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/apify/node_modules/@apify/log": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-      "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-      "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "ansi-colors": "^4.1.1"
-      }
-    },
-    "node_modules/apify/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1926,14 +2605,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dependencies": {
-        "retry": "0.13.1"
-      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2148,26 +2819,6 @@
         }
       ]
     },
-    "node_modules/better-sqlite3-with-prebuilds": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3-with-prebuilds/-/better-sqlite3-with-prebuilds-7.4.3.tgz",
-      "integrity": "sha512-E1MWyMz5RFZCdRNzIcR245dRVR3u1qZO2uV+8Z9Vb/PJsQ6uxOuOnSfA+rZdkuvDbVTbdpowKNL1tuO6FJyt0A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@types/integer": "latest",
-        "bindings": "^1.5.0",
-        "prebuild-install": "^6.0.1",
-        "tar": "^6.1.0"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2204,111 +2855,36 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-pool": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/browser-pool/-/browser-pool-3.1.4.tgz",
-      "integrity": "sha512-vd++Ta4CQiyncPR/+RUjLM/BcervZ+bx9UvIRclQlLPq+KK7cPDhbj6T2u0q5iZMBMfRXVb1pMNsyD2MZRPCOA==",
-      "dependencies": {
-        "@apify/log": "^1.2.0",
-        "@apify/timeout": "^0.2.1",
-        "fingerprint-generator": "^1.0.0",
-        "fingerprint-injector": "^1.0.0",
-        "lodash.merge": "^4.6.2",
-        "nanoid": "^3.3.3",
-        "ow": "^0.27.0",
-        "p-limit": "^3.1.0",
-        "proxy-chain": "^2.0.1",
-        "quick-lru": "^5.1.1",
-        "tiny-typed-emitter": "^2.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=15.10.0"
-      }
-    },
-    "node_modules/browser-pool/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/browser-pool/node_modules/@apify/log": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-      "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-      "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "ansi-colors": "^4.1.1"
-      }
-    },
-    "node_modules/browser-pool/node_modules/ow": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.1",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.1",
-        "vali-date": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/browser-pool/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/browser-pool/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -2358,9 +2934,9 @@
       "dev": true
     },
     "node_modules/cacheable-lookup": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
-      "integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -2427,13 +3003,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001311",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz",
-      "integrity": "sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -2464,17 +3046,17 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "dependencies": {
-        "cheerio-select": "^1.5.0",
-        "dom-serializer": "^1.3.2",
-        "domhandler": "^4.2.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1",
-        "tslib": "^2.2.0"
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
       },
       "engines": {
         "node": ">= 6"
@@ -2484,44 +3066,30 @@
       }
     },
     "node_modules/cheerio-select": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "dependencies": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cheerio/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "engines": {
-        "node": ">=10"
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/ci-info": {
@@ -2570,6 +3138,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2611,14 +3180,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -2686,18 +3247,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/compress-brotli": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
-      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-      "dependencies": {
-        "@types/json-buffer": "~3.0.0",
-        "json-buffer": "~3.0.1"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2708,11 +3257,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
       "dev": true
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -2731,10 +3275,41 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    "node_modules/crawlee": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.1.4.tgz",
+      "integrity": "sha512-6jPo37PbKL2oHF99mqWFRQKs32HRiXbXba9GeMhMMRtwXz4CXPNWPr2l1edLlcX3APPN776P8uh6VW30hbqdhg==",
+      "dependencies": {
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/cheerio": "^3.1.4",
+        "@crawlee/cli": "^3.1.2",
+        "@crawlee/core": "^3.1.3",
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/jsdom": "^3.1.4",
+        "@crawlee/playwright": "^3.1.4",
+        "@crawlee/puppeteer": "^3.1.4",
+        "@crawlee/utils": "^3.1.2",
+        "import-local": "^3.1.0"
+      },
+      "bin": {
+        "crawlee": "cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "playwright": ">= 1.21.x <= 1.27.x",
+        "puppeteer": "<= 19.x"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -2759,14 +3334,14 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       },
       "funding": {
@@ -2805,19 +3380,31 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
-    "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    "node_modules/csv-stringify": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.3.tgz",
+      "integrity": "sha512-4qGjUMwnlaRc00gc2jrIYh2w/h1fo25B0mTuY9K8fBiIgtmCX3LcgUbrEGViL98Ci4Se/F5LFEtu8k+dItJVZQ=="
     },
     "node_modules/data-urls": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
-      "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dependencies": {
-        "abab": "^2.0.3",
+        "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0"
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -2840,9 +3427,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2863,14 +3450,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2922,30 +3501,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
-    "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2982,13 +3537,13 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
@@ -3017,11 +3572,11 @@
       }
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -3031,13 +3586,13 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -3062,10 +3617,15 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz",
-      "integrity": "sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -3098,9 +3658,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -3800,14 +4363,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
@@ -3883,8 +4438,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -3925,6 +4479,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
+    "node_modules/figlet": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
+      "integrity": "sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -3951,11 +4513,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3981,71 +4538,40 @@
       }
     },
     "node_modules/fingerprint-generator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-1.0.0.tgz",
-      "integrity": "sha512-83I+qX+BZPnO2xHWTUpKTYckRvQFDd0sB8YPKLAprbBC6tY2Gz/FQjGPoGvprnpz9V5TPAl9fzXVSskkCW5ZoQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.7.tgz",
+      "integrity": "sha512-3SiwtxLOi2d/lBpJxHhvW8z1z4yavPv/GBUWaTEvCKAVr84I8bvVVabmO43ntDiBbHytwaWDm9oDyAucZQebYw==",
       "dependencies": {
-        "csv-parse": "^4.15.3",
-        "generative-bayesian-network": "0.1.0-beta.1",
-        "header-generator": "^1.1.3",
-        "ow": "^0.24.1"
-      }
-    },
-    "node_modules/fingerprint-generator/node_modules/ow": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.24.1.tgz",
-      "integrity": "sha512-RblFPB9PV1U0dNaQKmvnq3RkPb+B0lQjou1YakpAPxy8pQXIZqIfXtqvcft8KRKPgTJjtYQTYy1JvxzAviN1mA==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.0",
-        "vali-date": "^1.0.0"
+        "generative-bayesian-network": "^2.1.7",
+        "header-generator": "^2.1.7",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/fingerprint-generator/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fingerprint-injector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-1.0.0.tgz",
-      "integrity": "sha512-dZD1FJuL8otwG+etuCBl0uNFMSWoZAbr2fhW2KWrLdMX0ryL9GG/11BBM/Pw7V6Iej+zx8EUZNz9TMhSwgyTEw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.7.tgz",
+      "integrity": "sha512-DqXEgRkiQybOJjivMmemRr76D6i7fFJSJ6BfaCu1CUvc2xgrHIwTz95mPxxUn52XE1cQOZnJw1O1GME7hgLLhg==",
       "dependencies": {
-        "@apify/log": "^1.0.5",
-        "tslib": "^2.3.1",
-        "useragent": "^2.3.0"
+        "fingerprint-generator": "^2.1.7",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=15.10.0"
-      }
-    },
-    "node_modules/fingerprint-injector/node_modules/@apify/consts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-      "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-    },
-    "node_modules/fingerprint-injector/node_modules/@apify/log": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-      "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-      "dependencies": {
-        "@apify/consts": "^1.11.0",
-        "ansi-colors": "^4.1.1"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "playwright": "^1.22.2",
+        "puppeteer": ">= 9.x"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
       }
     },
     "node_modules/flat-cache": {
@@ -4105,9 +4631,9 @@
       }
     },
     "node_modules/form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
     },
     "node_modules/from": {
       "version": "0.1.7",
@@ -4132,17 +4658,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4160,100 +4675,13 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/generative-bayesian-network": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-0.1.0-beta.1.tgz",
-      "integrity": "sha512-V+yQLb98dDU9vzwE7R+0kdEY3+cVu16+qg+VQEhrTXPcZj2EyPACJtnkSzFkKb4yDcnA3HM/L22kVIh0lF7GXg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.7.tgz",
+      "integrity": "sha512-JY3pkkWA/Wm0UG/7sp/BX14U6G5GTjufsFucVMNqS6rNvyEr9EXT4KE/iEFNUwjpQW4KutvlpAhkABCnANR2nA==",
       "dependencies": {
-        "ow": "^0.23.0"
-      }
-    },
-    "node_modules/generative-bayesian-network/node_modules/ow": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-      "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.0",
-        "vali-date": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/generative-bayesian-network/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "adm-zip": "^0.5.9",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/gensync": {
@@ -4323,11 +4751,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
-    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4369,23 +4792,22 @@
       }
     },
     "node_modules/got-cjs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/got-cjs/-/got-cjs-12.0.1.tgz",
-      "integrity": "sha512-tRcTpee77XR9PNOp2Pu1P/XD67zkdeaBJ8kFz90for9dDTg6tqQKe64ORPbxFnB0mECKB+PQKCTcvJJdhv265g==",
+      "version": "12.5.4",
+      "resolved": "https://registry.npmjs.org/got-cjs/-/got-cjs-12.5.4.tgz",
+      "integrity": "sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==",
       "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
+        "@sindresorhus/is": "4.6.0",
         "@szmarczak/http-timer": "4.0.6",
-        "@types/cacheable-request": "^6.0.2",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^6.0.4",
-        "cacheable-request": "^7.0.2",
+        "@types/responselike": "1.0.0",
+        "cacheable-lookup": "6.1.0",
+        "cacheable-request": "7.0.2",
         "decompress-response": "^6.0.0",
-        "form-data-encoder": "1.7.1",
+        "form-data-encoder": "1.7.2",
         "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.9",
+        "http2-wrapper": "^2.1.10",
         "lowercase-keys": "2.0.0",
         "p-cancelable": "2.1.1",
-        "responselike": "^2.0.0"
+        "responselike": "2.0.1"
       },
       "engines": {
         "node": ">=12"
@@ -4395,64 +4817,20 @@
       }
     },
     "node_modules/got-scraping": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-3.2.9.tgz",
-      "integrity": "sha512-mMTyGHnIgLeJWCQ9x6fGR0Mzp5xcos5FxZz7HTs6Ao9x3a058Le/iadlgUYTjRZ6+0R7n+2ap6/YKU4l66FUkw==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-3.2.12.tgz",
+      "integrity": "sha512-6i01LoQf853Hsa0pMHrHnCH/ZoJNtA6MHGAAGJR48RuRIYQox7uv6VVa4GgcKcIqKmGVDYGl4Et2MOG/wsL7qQ==",
       "dependencies": {
-        "got-cjs": "12.0.1",
-        "header-generator": "2.0.0-beta.10",
-        "http2-wrapper": "^2.1.4",
+        "got-cjs": "12.5.4",
+        "header-generator": "^2.1.3",
+        "http2-wrapper": "^2.1.11",
         "mimic-response": "^3.1.0",
-        "ow": "^0.23.0",
+        "ow": "^0.28.1",
         "quick-lru": "^5.1.1",
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=15.10.0"
-      }
-    },
-    "node_modules/got-scraping/node_modules/header-generator": {
-      "version": "2.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.0.0-beta.10.tgz",
-      "integrity": "sha512-yN4YCZzoAS/sE3LTj5lLy42B7zy7nxfDEU1Nt3vCjUGjlIMYB6UdNj2WJEZHP9s1Y9tp2zkdRfZg43ewZvcyOQ==",
-      "dependencies": {
-        "browserslist": "^4.19.1",
-        "generative-bayesian-network": "0.1.0-beta.1",
-        "ow": "^0.23.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=15.10.0"
-      }
-    },
-    "node_modules/got-scraping/node_modules/ow": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-      "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.0",
-        "vali-date": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/got-scraping/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -4470,6 +4848,25 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -4517,48 +4914,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
-    },
     "node_modules/header-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-1.1.3.tgz",
-      "integrity": "sha512-BqbsjZJHyQVJCrqqFL9IC3VJ77VqokxLggsWk9uqSM3mEQrtyIWo2PBJ023qoYSZRa9PuOEw5Uas/xRvQbVhTg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.7.tgz",
+      "integrity": "sha512-VCQw0Xk0gc2CcNj+3qWv1FBpaPxTWUdvB8dzeidMP8pw/5PDZVPatAqLMFPkotkk4eoTOn7GWh5z2N1B1CGn4Q==",
       "dependencies": {
-        "generative-bayesian-network": "0.1.0-beta.1",
-        "ow": "^0.23.0"
-      }
-    },
-    "node_modules/header-generator/node_modules/ow": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-      "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.0",
-        "vali-date": "^1.0.0"
+        "browserslist": "^4.21.1",
+        "generative-bayesian-network": "^2.1.7",
+        "ow": "^0.28.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/header-generator/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4579,9 +4946,9 @@
       "dev": true
     },
     "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4590,21 +4957,10 @@
         }
       ],
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -4626,9 +4982,9 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
-      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -4656,14 +5012,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -4734,7 +5082,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
       "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-      "dev": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -4771,11 +5118,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/inquirer": {
       "version": "8.2.0",
@@ -5140,11 +5482,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7182,9 +7519,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7320,7 +7657,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -7340,11 +7676,10 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
-      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dependencies": {
-        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -7408,7 +7743,7 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7523,6 +7858,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7630,41 +7966,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "node_modules/minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -7700,32 +8003,11 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -7772,9 +8054,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -7808,17 +8090,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -7830,26 +8101,10 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "node_modules/object-inspect": {
       "version": "1.11.0",
@@ -8060,30 +8315,18 @@
       }
     },
     "node_modules/ow": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.1.tgz",
-      "integrity": "sha512-1EZTywPZeUKac9gD7q8np3Aj+V54kvfIcjNEVNDSbG2Ys5xA5foW2HquvMMqgyWGLqIFMlc0Iq/HmyMHqN48sA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.2.tgz",
+      "integrity": "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==",
       "dependencies": {
         "@sindresorhus/is": "^4.2.0",
         "callsites": "^3.1.0",
         "dot-prop": "^6.0.1",
         "lodash.isequal": "^4.5.0",
-        "type-fest": "^2.3.4",
         "vali-date": "^1.0.0"
       },
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ow/node_modules/type-fest": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8163,6 +8406,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/parent-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
+      "integrity": "sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8187,11 +8438,26 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
       "dependencies": {
-        "parse5": "^6.0.1"
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -8275,32 +8541,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8371,11 +8611,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8397,10 +8632,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-chain": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.0.5.tgz",
-      "integrity": "sha512-rTPAV0P9dCFoR3tV23cQIT3K6DfBQUh69n2Cvy3RqYFX4zegrIhWAbpVoffJaMFvoPHIIGKG0WcKQapKCjpZuQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.2.0.tgz",
+      "integrity": "sha512-kUzDckuWeZe8TiP2q872BzPKchiylEf2Hgy6knC2yIEKtAT592NkzQjMRLi+CxjDZSWrcXTFTPw/0WbpfdDiCA==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -8412,11 +8657,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -8483,6 +8723,11 @@
         }
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -8492,28 +8737,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -8555,6 +8778,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -8577,7 +8805,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -8589,7 +8816,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8627,9 +8853,9 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "engines": {
         "node": ">= 4"
       }
@@ -8657,22 +8883,18 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dependencies": {
-        "tslib": "~2.1.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.3.1",
@@ -8711,11 +8933,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8756,57 +8973,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-get/node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/simple-get/node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -8910,9 +9076,9 @@
       }
     },
     "node_modules/stream-json": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.4.tgz",
-      "integrity": "sha512-ja2dde1v7dOlx5/vmavn8kLrxvNfs7r2oNc5DYmNJzayDDdudyCSuTB1gFjH4XBVTIwxiMxL4i059HX+ZiouXg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.5.tgz",
+      "integrity": "sha512-NSkoVduGakxZ8a+pTPUlcGEeAGQpWL9rKJhOFCV+J/QtdQUEU5vtBgVg6eJXn8JB8RZvpbJWZGvXkhz70MLWoA==",
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -9088,22 +9254,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -9192,6 +9342,22 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
+    "node_modules/tldts": {
+      "version": "5.7.104",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.104.tgz",
+      "integrity": "sha512-PlziEIVPH/ogbqOhS35K6MOeD09rd9U5g2NHO5n9NZeMC1PGpXgsjQpoJ1KiRnjhZsWDkzN8EoX3xQZuz5ZyFQ==",
+      "dependencies": {
+        "tldts-core": "^5.7.104"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "5.7.104",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.104.tgz",
+      "integrity": "sha512-8vhSgc2nzPNT0J7XyCqcOtQ6+ySBn+gsPmj5h95YytIZ7L2Xl40paUmj0T6Uko42HegHGQxXieunHIQuABWSmQ=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -9231,22 +9397,23 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -9301,20 +9468,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9381,17 +9537,37 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
-    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -9403,28 +9579,14 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/useragent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dependencies": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/useragent/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/useragent/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -9463,7 +9625,7 @@
     "node_modules/vali-date": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9582,14 +9744,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/winston": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
@@ -9698,6 +9852,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -9758,29 +9913,103 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yargonaut": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/yargonaut/-/yargonaut-1.1.4.tgz",
+      "integrity": "sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==",
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "figlet": "^1.1.1",
+        "parent-require": "^1.0.0"
+      }
+    },
+    "node_modules/yargonaut/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargonaut/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargonaut/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargonaut/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yargonaut/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -9817,21 +10046,21 @@
       }
     },
     "@apify/consts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.3.0.tgz",
-      "integrity": "sha512-9SkEA9aOy+hqE3ayA9aHnoVTFYYEDn41Q9EjU4sVSaCrxHLp9MQqdiGYQnXrmmCtbxbj/pJeb6MLxnACI5e/yg=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.8.0.tgz",
+      "integrity": "sha512-uQBRggMka8HtpkLWJeA9ZITDxgAgpwDoL1Uj8QXGaZDj0Rb7Z7YcEAJ8KNRoj0yuIlqoS6NwNWEwfpFIjSYt3Q=="
     },
     "@apify/datastructures": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-1.0.1.tgz",
-      "integrity": "sha512-AgnrfMjzDph+Te5WGNnIsz3+dJM7v/Sqo82nWwSqca292paRotUhORXr9Ik+d0yurC5LutDAhcvu8VZ8SfANGg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.0.tgz",
+      "integrity": "sha512-O7I31PvG4Qb/Zc2lAIkSUBRDLKDKLrmqtWG3Ea8To5xvbPKdiLuVx3IuAzjCs1UQVTbhN590Sw5xBoFghreAYA=="
     },
     "@apify/log": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.1.3.tgz",
-      "integrity": "sha512-HhL7zZJecFzYNxdbLS8OttixvShZRbzW6UAms/oKAGuFn1O/L+AWy6jk8zrTbg7QY9lPk9FfdXM3OO+vza6mSw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.2.5.tgz",
+      "integrity": "sha512-wJPIytLWy3iVjFaJUHH6FvtyoSiLFeArjbVJ9xFzQ+lFeHxPLTMIgC2H/6EknP7T/n/7v0SkbSmsbHNtsPGnEQ==",
       "requires": {
-        "@apify/consts": "^2.3.0",
+        "@apify/consts": "^2.8.0",
         "ansi-colors": "^4.1.1"
       }
     },
@@ -9843,65 +10072,27 @@
         "event-stream": "3.3.4"
       }
     },
-    "@apify/storage-local": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.1.0.tgz",
-      "integrity": "sha512-oKz+fYJ6IsaOH4JQpfq3DSpOhKHd3muMuqd50dv8QV68ia9goFFnc804rb6yaPvNIcGbp8xREPqu0VMFy2iEjg==",
+    "@apify/pseudo_url": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.11.tgz",
+      "integrity": "sha512-tjPHT/8bqU7dvyW9TMT1pAMNKRJ5Upg1pN2EQqDNuD/hp6aUFLmsN4X1IQugyAy5hLqzgk81XQJ6lgKiwWjgHQ==",
       "requires": {
-        "@apify/consts": "^1.10.0",
-        "@apify/log": "^1.2.3",
-        "better-sqlite3-with-prebuilds": "^7.4.3",
-        "content-type": "^1.0.4",
-        "fs-extra": "^10.1.0",
-        "mime-types": "^2.1.35",
-        "ow": "^0.28.1",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "@apify/log": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-          "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-          "requires": {
-            "@apify/consts": "^1.11.0",
-            "ansi-colors": "^4.1.1"
-          }
-        }
+        "@apify/log": "^2.2.5",
+        "@sapphire/shapeshift": "^3.6.0"
       }
     },
     "@apify/timeout": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.2.1.tgz",
-      "integrity": "sha512-487pqjk6OZXcTeAJlby7Kwu65d2dLl/LMcVqUXjcCoRvfGn3hRMAkd0GHHWuJzknY4Zh8pKM9qtj5AS3fPKEQw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.0.tgz",
+      "integrity": "sha512-jLwg4vC1hHsU1UWbwO5suYFGPBANPy5Dovc6P9y56TZ1B2RsRYjfDaX3BdfaAa6E2akib19EinF9EjuN13m5AA=="
     },
     "@apify/utilities": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-1.2.14.tgz",
-      "integrity": "sha512-UejFdqZrK1DIxApxS0GQDISpd68wCz++1Bh/JEw8qD7ZxWA6P5Huh5smIv8bSTRXzUbFhobpIVie/2OMIrM30A==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.2.7.tgz",
+      "integrity": "sha512-uHwndKAgwRvj5ovWo9cdut5oBJVwcl1qWCP7Dj9zQkXOezbTTtRYIki7DkeUC3PFIP/R8yn9l7BMsLizelFe2w==",
       "requires": {
-        "@apify/consts": "^1.11.0",
-        "@apify/log": "^1.2.5"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "@apify/log": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-          "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-          "requires": {
-            "@apify/consts": "^1.11.0",
-            "ansi-colors": "^4.1.1"
-          }
-        }
+        "@apify/consts": "^2.8.0",
+        "@apify/log": "^2.2.5"
       }
     },
     "@babel/code-frame": {
@@ -10261,6 +10452,602 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@crawlee/basic": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.1.4.tgz",
+      "integrity": "sha512-8ON2ZOMERpzQ1WZ7D+aFfD1OnpOsrrf2U6cnYX62u+/XIuchEpjbfCCoX1A39Xq8ZwlkJJSUCp2kbqGZDhsHww==",
+      "requires": {
+        "@apify/log": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/core": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "got-scraping": "^3.2.9",
+        "ow": "^0.28.1",
+        "type-fest": "^3.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+          "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA=="
+        }
+      }
+    },
+    "@crawlee/browser": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.1.4.tgz",
+      "integrity": "sha512-7cS+c5WPgK9DKNr0JHeRmJwOGHFBguISrkgTLe/9JyAjK8zcvBHZBWrzvpfZfdVsFcsn61typPCfefs+mxcGbg==",
+      "requires": {
+        "@apify/timeout": "^0.3.0",
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "ow": "^0.28.1"
+      }
+    },
+    "@crawlee/browser-pool": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.1.3.tgz",
+      "integrity": "sha512-0eZj87zw4FiH5WkUQnXZ+tbFq4JaTYmPHYd8NruLKKtewto0HYMuuiVLkhfrm+YR93PkZt3SQuErkek+s1vXLw==",
+      "requires": {
+        "@apify/log": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@crawlee/types": "^3.1.2",
+        "fingerprint-generator": "^2.0.6",
+        "fingerprint-injector": "^2.0.5",
+        "lodash.merge": "^4.6.2",
+        "nanoid": "^3.3.4",
+        "ow": "^0.28.1",
+        "p-limit": "^3.1.0",
+        "proxy-chain": "^2.0.1",
+        "quick-lru": "^5.1.1",
+        "tiny-typed-emitter": "^2.1.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
+    },
+    "@crawlee/cheerio": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.1.4.tgz",
+      "integrity": "sha512-rkkX1aqewU2qI4QxCduTIcgjE6IijaE01ShYf9mUQBOQRCg5bl2ktk0cSuNvx3DSkjEsZkfEfanQMMLV2/WfBA==",
+      "requires": {
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "htmlparser2": "^8.0.1"
+      }
+    },
+    "@crawlee/cli": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.1.2.tgz",
+      "integrity": "sha512-NPhZ4KUyb04vq9n5uLYFy9iTQlbNg/+87MnKJ1fFNdUN/dFrBR01zcL7r2IcJqzPaRrRp9cWJwQ4kcXbeDfqOg==",
+      "requires": {
+        "@crawlee/templates": "^3.1.2",
+        "ansi-colors": "^4.1.3",
+        "fs-extra": "^10.1.0",
+        "inquirer": "^8.2.4",
+        "yargonaut": "^1.1.4",
+        "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "inquirer": {
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+          "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.1.1",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^3.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "0.0.8",
+            "ora": "^5.4.1",
+            "run-async": "^2.4.0",
+            "rxjs": "^7.5.5",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@crawlee/core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.1.3.tgz",
+      "integrity": "sha512-aiI3m4jBF70Jiq1oD7xjqE9QW1eUHftyB3oANXtvIIbnUyxkP63IEhAe096TgEyPeOfnNGFOOEUNbI5OmwKOpw==",
+      "requires": {
+        "@apify/consts": "^2.0.0",
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@apify/pseudo_url": "^2.0.0",
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/memory-storage": "^3.1.2",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "@types/tough-cookie": "^4.0.2",
+        "@vladfrangu/async_event_emitter": "^2.0.0",
+        "csv-stringify": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "json5": "^2.2.1",
+        "minimatch": "^5.1.0",
+        "ow": "^0.28.1",
+        "stream-chain": "^2.2.5",
+        "stream-json": "^1.7.4",
+        "tldts": "^5.7.80",
+        "tough-cookie": "^4.0.0",
+        "type-fest": "^3.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+          "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA=="
+        }
+      }
+    },
+    "@crawlee/http": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.1.4.tgz",
+      "integrity": "sha512-DEpIWTTmc0MpbIAzIRkIoMHOJOS4hG4BCjq/WFlJcB/sm4VreghUWxOMFOg5U3vndiHeN6aqIPMKX8rnI2Ig4Q==",
+      "requires": {
+        "@apify/timeout": "^0.3.0",
+        "@apify/utilities": "^2.0.0",
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "@types/content-type": "^1.1.5",
+        "content-type": "^1.0.4",
+        "got-scraping": "^3.2.9",
+        "iconv-lite": "^0.6.3",
+        "mime-types": "^2.1.35",
+        "ow": "^0.28.1",
+        "type-fest": "^3.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+          "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA=="
+        }
+      }
+    },
+    "@crawlee/jsdom": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.1.4.tgz",
+      "integrity": "sha512-Ni/gV1WmI+ikpL8jAo7yAsfm7sRaIHTRQd/Z5jyjm8BcC9aUNMOQRTlDCAnNLLVVAic9gZpJfxzojsK55Dhjzw==",
+      "requires": {
+        "@apify/utilities": "^2.1.4",
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/types": "^3.1.2",
+        "@types/jsdom": "^20.0.0",
+        "jsdom": "^20.0.0",
+        "ow": "^0.28.2"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+        },
+        "acorn-globals": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+          "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+          "requires": {
+            "acorn": "^8.1.0",
+            "acorn-walk": "^8.0.2"
+          }
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
+        "jsdom": {
+          "version": "20.0.3",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+          "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+          "requires": {
+            "abab": "^2.0.6",
+            "acorn": "^8.8.1",
+            "acorn-globals": "^7.0.0",
+            "cssom": "^0.5.0",
+            "cssstyle": "^2.3.0",
+            "data-urls": "^3.0.2",
+            "decimal.js": "^10.4.2",
+            "domexception": "^4.0.0",
+            "escodegen": "^2.0.0",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^3.0.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.1",
+            "is-potential-custom-element-name": "^1.0.1",
+            "nwsapi": "^2.2.2",
+            "parse5": "^7.1.1",
+            "saxes": "^6.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.1.2",
+            "w3c-xmlserializer": "^4.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^2.0.0",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^11.0.0",
+            "ws": "^8.11.0",
+            "xml-name-validator": "^4.0.0"
+          }
+        },
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        },
+        "saxes": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+          "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+          "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+          "requires": {
+            "xml-name-validator": "^4.0.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        },
+        "ws": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+          "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+          "requires": {}
+        }
+      }
+    },
+    "@crawlee/memory-storage": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.1.2.tgz",
+      "integrity": "sha512-+ciFZmwhrIUmshUx+rx5CBRZ7nOT8K7I0jWp5QrSKBNFnpvR/PW89QjR8cWAUHRz69p7kicMrgXUroGzgZ9h7w==",
+      "requires": {
+        "@apify/log": "^2.0.0",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "@sapphire/shapeshift": "^3.0.0",
+        "content-type": "^1.0.4",
+        "fs-extra": "^10.1.0",
+        "json5": "^2.2.1",
+        "mime-types": "^2.1.35",
+        "proper-lockfile": "^4.1.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@crawlee/playwright": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.1.4.tgz",
+      "integrity": "sha512-sVO0neH7lVM3BYEoGVm1iv99M9yaI52Om4QCNJSJ0SdFdpeABM3Lpm/K/sLzoAai70y/VFlY+ofXL5hIVLPKBA==",
+      "requires": {
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "jquery": "^3.6.0",
+        "ow": "^0.28.1"
+      }
+    },
+    "@crawlee/puppeteer": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.1.4.tgz",
+      "integrity": "sha512-rSqALBbsmVfzQ0UsfLXuO4DEKhhTHm8BIzyNQWIAi0FxeW1CGUmwM63UM9jGSwRcZT4BcJETTqu+unwci9/yNQ==",
+      "requires": {
+        "@apify/datastructures": "^2.0.0",
+        "@apify/log": "^2.0.0",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/browser-pool": "^3.1.3",
+        "@crawlee/types": "^3.1.2",
+        "@crawlee/utils": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "devtools-protocol": "*",
+        "jquery": "^3.6.0",
+        "ow": "^0.28.1"
+      }
+    },
+    "@crawlee/templates": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.1.2.tgz",
+      "integrity": "sha512-ubhcg8C+Vk2kN4V7VvWh9B/9VOmN8jS56ePN1/VH4+faiaRxuMv4zftRXXXyVxbcDyhMM0BLyVIxNLt6iAY1iA==",
+      "requires": {
+        "ansi-colors": "^4.1.3",
+        "inquirer": "^9.0.0",
+        "yargonaut": "^1.1.4",
+        "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.0.0.tgz",
+          "integrity": "sha512-IG23inYII3dWlU2EyiAiGj6Bwal5GzsgPMwjYGvc1HPE2dgbj4ZB5ToWBKSquKw74nB3TIuOwaI6/jSULzfgrw==",
+          "requires": {
+            "type-fest": "^3.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+        },
+        "bl": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+          "requires": {
+            "buffer": "^6.0.3",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "chalk": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+        },
+        "cli-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+          "requires": {
+            "restore-cursor": "^4.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
+          "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
+          }
+        },
+        "inquirer": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.4.tgz",
+          "integrity": "sha512-9hiJxE5gkK/cM2d1mTEnuurGTAoHebbkX0BYl3h7iEg7FYfuNIom+nDfBCSWtvSnoSrWCeBxqqBZu26xdlJlXA==",
+          "requires": {
+            "ansi-escapes": "^6.0.0",
+            "chalk": "^5.1.2",
+            "cli-cursor": "^4.0.0",
+            "cli-width": "^4.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^5.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "0.0.8",
+            "ora": "^6.1.2",
+            "run-async": "^2.4.0",
+            "rxjs": "^7.5.7",
+            "string-width": "^5.1.2",
+            "strip-ansi": "^7.0.1",
+            "through": "^2.3.6",
+            "wrap-ansi": "^8.0.1"
+          }
+        },
+        "is-interactive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+        },
+        "is-unicode-supported": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+          "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+        },
+        "log-symbols": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+          "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+          "requires": {
+            "chalk": "^5.0.0",
+            "is-unicode-supported": "^1.1.0"
+          }
+        },
+        "ora": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+          "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+          "requires": {
+            "bl": "^5.0.0",
+            "chalk": "^5.0.0",
+            "cli-cursor": "^4.0.0",
+            "cli-spinners": "^2.6.1",
+            "is-interactive": "^2.0.0",
+            "is-unicode-supported": "^1.1.0",
+            "log-symbols": "^5.1.0",
+            "strip-ansi": "^7.0.1",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+          "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA=="
+        },
+        "wrap-ansi": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+          "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
+    "@crawlee/types": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.1.2.tgz",
+      "integrity": "sha512-DNT8slBUpmBJ/bwz2BVs/PRKbpczOuO45G2+hkRFHXZKJSG6HnJgqbZBPzIMtsTJ7Ztxg4xxv2wxiGNPFM25/Q==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@crawlee/utils": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-an8JUVQkmN+9NpTjwTtQOBBgfgK3id2quZHnIXLsFy9RE5lKBQmDZ7Q+AR2Qpndsnpm2WikTQrnvnFiDPYL8bg==",
+      "requires": {
+        "@apify/log": "^2.0.0",
+        "@apify/ps-tree": "^1.1.4",
+        "@crawlee/types": "^3.1.2",
+        "cheerio": "1.0.0-rc.12",
+        "got-scraping": "^3.2.9",
+        "tslib": "^2.4.0"
+      }
     },
     "@dabh/diagnostics": {
       "version": "2.0.2",
@@ -10831,10 +11618,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      }
+    },
     "@sindresorhus/is": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -10908,16 +11704,10 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/cacheable-request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
+    "@types/content-type": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.5.tgz",
+      "integrity": "sha512-dgMN+syt1xb7Hk8LU6AODOfPlvz5z1CbXpPuJE5ZrX9STfBOIXF09pEB8N7a97WT9dbngt3ksDCm6GW6yMrxfQ=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -10927,16 +11717,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
-    },
-    "@types/integer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/integer/-/integer-4.0.1.tgz",
-      "integrity": "sha512-QQojPymFcV1hrvWXA1h0pP9RmFBFNuWikZcUEjjVsS19IyKO+jqOX24lp2ZHF4A21EmkosJhJDX7CLG67F2s7A=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -10962,24 +11742,31 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "@types/json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ=="
+    "@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        }
+      }
     },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "16.10.3",
@@ -11006,6 +11793,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -11030,10 +11822,15 @@
         "@types/node": "*"
       }
     },
+    "@vladfrangu/async_event_emitter": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.1.3.tgz",
+      "integrity": "sha512-o09Pcdu8T9eL9iWcVWuJQnHLvQMYqMNaR5E2PD80A+uuL/u3CR6j0pCmaP1ILVspdAN7yeLnoyo8wljMXArj7Q=="
+    },
     "abab": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -11061,22 +11858,17 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
-      }
-    },
-    "agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "requires": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
       }
     },
     "ajv": {
@@ -11128,145 +11920,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "apify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/apify/-/apify-2.3.2.tgz",
-      "integrity": "sha512-C60Wp6vav6yBhl9OPPiMPpYNKcxi2OmKHppdeNWzlJF6MNreh4MYDqwD8kb2D8f95Yl1cvv8zHJchRBDexdzSw==",
-      "requires": {
-        "@apify/consts": "^1.7.0",
-        "@apify/datastructures": "^1.0.1",
-        "@apify/log": "^1.2.0",
-        "@apify/ps-tree": "^1.1.4",
-        "@apify/storage-local": "^2.0.2",
-        "@apify/timeout": "^0.2.1",
-        "@apify/utilities": "^1.2.8",
-        "apify-client": "^2.3.1",
-        "browser-pool": "^3.1.3",
-        "cheerio": "1.0.0-rc.10",
-        "content-type": "^1.0.4",
-        "got-scraping": "^3.2.9",
-        "htmlparser2": "^7.0.0",
-        "iconv-lite": "^0.6.3",
-        "jquery": "^3.6.0",
-        "mime-types": "^2.1.35",
-        "ow": "^0.28.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "stream-json": "^1.7.4",
-        "tough-cookie": "^4.0.0",
-        "underscore": "^1.13.3",
-        "ws": "^7.5.7"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "@apify/log": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-          "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-          "requires": {
-            "@apify/consts": "^1.11.0",
-            "ansi-colors": "^4.1.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "apify-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.6.0.tgz",
-      "integrity": "sha512-qbMfwx/765MT7rh5aqBy5xrj0howOibCrAEIQpWD7zqa4fCpKfGk/8z+MkEXBsgoWNWLR0wRl5/CCTmSjH6+Jw==",
-      "requires": {
-        "@apify/consts": "^1.4.0",
-        "@apify/log": "^2.1.0",
-        "agentkeepalive": "^4.1.4",
-        "async-retry": "^1.3.1",
-        "axios": "^0.21.1",
-        "content-type": "^1.0.4",
-        "ow": "^0.27.0"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        },
-        "ow": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-          "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.1",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.1",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -11304,14 +11957,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "requires": {
-        "retry": "0.13.1"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -11469,25 +12114,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "better-sqlite3-with-prebuilds": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3-with-prebuilds/-/better-sqlite3-with-prebuilds-7.4.3.tgz",
-      "integrity": "sha512-E1MWyMz5RFZCdRNzIcR245dRVR3u1qZO2uV+8Z9Vb/PJsQ6uxOuOnSfA+rZdkuvDbVTbdpowKNL1tuO6FJyt0A==",
-      "requires": {
-        "@types/integer": "latest",
-        "bindings": "^1.5.0",
-        "prebuild-install": "^6.0.1",
-        "tar": "^6.1.0"
-      }
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -11521,82 +12147,20 @@
         "fill-range": "^7.0.1"
       }
     },
-    "browser-pool": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/browser-pool/-/browser-pool-3.1.4.tgz",
-      "integrity": "sha512-vd++Ta4CQiyncPR/+RUjLM/BcervZ+bx9UvIRclQlLPq+KK7cPDhbj6T2u0q5iZMBMfRXVb1pMNsyD2MZRPCOA==",
-      "requires": {
-        "@apify/log": "^1.2.0",
-        "@apify/timeout": "^0.2.1",
-        "fingerprint-generator": "^1.0.0",
-        "fingerprint-injector": "^1.0.0",
-        "lodash.merge": "^4.6.2",
-        "nanoid": "^3.3.3",
-        "ow": "^0.27.0",
-        "p-limit": "^3.1.0",
-        "proxy-chain": "^2.0.1",
-        "quick-lru": "^5.1.1",
-        "tiny-typed-emitter": "^2.1.0",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "@apify/log": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-          "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-          "requires": {
-            "@apify/consts": "^1.11.0",
-            "ansi-colors": "^4.1.1"
-          }
-        },
-        "ow": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-          "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.1",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.1",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
-      }
-    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "bser": {
@@ -11629,9 +12193,9 @@
       "dev": true
     },
     "cacheable-lookup": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
-      "integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww=="
     },
     "cacheable-request": {
       "version": "7.0.2",
@@ -11679,9 +12243,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001311",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz",
-      "integrity": "sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A=="
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -11706,48 +12270,41 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "cheerio": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "requires": {
-        "cheerio-select": "^1.5.0",
-        "dom-serializer": "^1.3.2",
-        "domhandler": "^4.2.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1",
-        "tslib": "^2.2.0"
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
       },
       "dependencies": {
-        "htmlparser2": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
           "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
+            "entities": "^4.4.0"
           }
         }
       }
     },
     "cheerio-select": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "requires": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
       }
-    },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "ci-info": {
       "version": "3.3.0",
@@ -11783,6 +12340,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -11814,11 +12372,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -11879,15 +12432,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "compress-brotli": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
-      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-      "requires": {
-        "@types/json-buffer": "~3.0.0",
-        "json-buffer": "~3.0.1"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11898,11 +12442,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
       "dev": true
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "content-type": {
       "version": "1.0.4",
@@ -11918,10 +12457,23 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    "crawlee": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.1.4.tgz",
+      "integrity": "sha512-6jPo37PbKL2oHF99mqWFRQKs32HRiXbXba9GeMhMMRtwXz4CXPNWPr2l1edLlcX3APPN776P8uh6VW30hbqdhg==",
+      "requires": {
+        "@crawlee/basic": "^3.1.4",
+        "@crawlee/browser": "^3.1.4",
+        "@crawlee/cheerio": "^3.1.4",
+        "@crawlee/cli": "^3.1.2",
+        "@crawlee/core": "^3.1.3",
+        "@crawlee/http": "^3.1.4",
+        "@crawlee/jsdom": "^3.1.4",
+        "@crawlee/playwright": "^3.1.4",
+        "@crawlee/puppeteer": "^3.1.4",
+        "@crawlee/utils": "^3.1.2",
+        "import-local": "^3.1.0"
+      }
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -11943,14 +12495,14 @@
       }
     },
     "css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       }
     },
@@ -11979,19 +12531,30 @@
         }
       }
     },
-    "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    "csv-stringify": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.3.tgz",
+      "integrity": "sha512-4qGjUMwnlaRc00gc2jrIYh2w/h1fo25B0mTuY9K8fBiIgtmCX3LcgUbrEGViL98Ci4Se/F5LFEtu8k+dItJVZQ=="
     },
     "data-urls": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
-      "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "requires": {
-        "abab": "^2.0.3",
+        "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0"
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "debug": {
@@ -12003,9 +12566,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -12020,11 +12583,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -12064,21 +12622,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -12106,13 +12649,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       }
     },
     "domelementtype": {
@@ -12129,21 +12672,21 @@
       }
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       }
     },
     "dot-prop": {
@@ -12159,10 +12702,15 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "electron-to-chromium": {
-      "version": "1.4.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz",
-      "integrity": "sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12189,9 +12737,9 @@
       }
     },
     "entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -12711,11 +13259,6 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-    },
     "expect": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
@@ -12772,8 +13315,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -12814,6 +13356,11 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
+    "figlet": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
+      "integrity": "sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -12830,11 +13377,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -12855,60 +13397,22 @@
       }
     },
     "fingerprint-generator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-1.0.0.tgz",
-      "integrity": "sha512-83I+qX+BZPnO2xHWTUpKTYckRvQFDd0sB8YPKLAprbBC6tY2Gz/FQjGPoGvprnpz9V5TPAl9fzXVSskkCW5ZoQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.7.tgz",
+      "integrity": "sha512-3SiwtxLOi2d/lBpJxHhvW8z1z4yavPv/GBUWaTEvCKAVr84I8bvVVabmO43ntDiBbHytwaWDm9oDyAucZQebYw==",
       "requires": {
-        "csv-parse": "^4.15.3",
-        "generative-bayesian-network": "0.1.0-beta.1",
-        "header-generator": "^1.1.3",
-        "ow": "^0.24.1"
-      },
-      "dependencies": {
-        "ow": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.24.1.tgz",
-          "integrity": "sha512-RblFPB9PV1U0dNaQKmvnq3RkPb+B0lQjou1YakpAPxy8pQXIZqIfXtqvcft8KRKPgTJjtYQTYy1JvxzAviN1mA==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.0",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
+        "generative-bayesian-network": "^2.1.7",
+        "header-generator": "^2.1.7",
+        "tslib": "^2.4.0"
       }
     },
     "fingerprint-injector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-1.0.0.tgz",
-      "integrity": "sha512-dZD1FJuL8otwG+etuCBl0uNFMSWoZAbr2fhW2KWrLdMX0ryL9GG/11BBM/Pw7V6Iej+zx8EUZNz9TMhSwgyTEw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.7.tgz",
+      "integrity": "sha512-DqXEgRkiQybOJjivMmemRr76D6i7fFJSJ6BfaCu1CUvc2xgrHIwTz95mPxxUn52XE1cQOZnJw1O1GME7hgLLhg==",
       "requires": {
-        "@apify/log": "^1.0.5",
-        "tslib": "^2.3.1",
-        "useragent": "^2.3.0"
-      },
-      "dependencies": {
-        "@apify/consts": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.11.0.tgz",
-          "integrity": "sha512-5tFbj/t+zqQDxMYKKUbAvgdkalZPNWWJjcL7AlyslwdZXkNaxUWD3CCXLz/hHvQ5otLuxGa7GuRQEcrkL6+jYw=="
-        },
-        "@apify/log": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.2.5.tgz",
-          "integrity": "sha512-gTaRzdhJ0qmcBLsFULlLz/jUUCw+0whC6G6TFt+VYHwWwWsIAwo5aSvww7nTq6xBNoKLXgZY/fEyUIDAQ7ekXA==",
-          "requires": {
-            "@apify/consts": "^1.11.0",
-            "ansi-colors": "^4.1.1"
-          }
-        }
+        "fingerprint-generator": "^2.1.7",
+        "tslib": "^2.4.0"
       }
     },
     "flat-cache": {
@@ -12948,9 +13452,9 @@
       }
     },
     "form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
     },
     "from": {
       "version": "0.1.7",
@@ -12972,14 +13476,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -12997,80 +13493,13 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
     "generative-bayesian-network": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-0.1.0-beta.1.tgz",
-      "integrity": "sha512-V+yQLb98dDU9vzwE7R+0kdEY3+cVu16+qg+VQEhrTXPcZj2EyPACJtnkSzFkKb4yDcnA3HM/L22kVIh0lF7GXg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.7.tgz",
+      "integrity": "sha512-JY3pkkWA/Wm0UG/7sp/BX14U6G5GTjufsFucVMNqS6rNvyEr9EXT4KE/iEFNUwjpQW4KutvlpAhkABCnANR2nA==",
       "requires": {
-        "ow": "^0.23.0"
-      },
-      "dependencies": {
-        "ow": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-          "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.0",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
+        "adm-zip": "^0.5.9",
+        "tslib": "^2.4.0"
       }
     },
     "gensync": {
@@ -13116,11 +13545,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
-    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -13150,68 +13574,36 @@
       "dev": true
     },
     "got-cjs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/got-cjs/-/got-cjs-12.0.1.tgz",
-      "integrity": "sha512-tRcTpee77XR9PNOp2Pu1P/XD67zkdeaBJ8kFz90for9dDTg6tqQKe64ORPbxFnB0mECKB+PQKCTcvJJdhv265g==",
+      "version": "12.5.4",
+      "resolved": "https://registry.npmjs.org/got-cjs/-/got-cjs-12.5.4.tgz",
+      "integrity": "sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==",
       "requires": {
-        "@sindresorhus/is": "^4.2.0",
+        "@sindresorhus/is": "4.6.0",
         "@szmarczak/http-timer": "4.0.6",
-        "@types/cacheable-request": "^6.0.2",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^6.0.4",
-        "cacheable-request": "^7.0.2",
+        "@types/responselike": "1.0.0",
+        "cacheable-lookup": "6.1.0",
+        "cacheable-request": "7.0.2",
         "decompress-response": "^6.0.0",
-        "form-data-encoder": "1.7.1",
+        "form-data-encoder": "1.7.2",
         "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.9",
+        "http2-wrapper": "^2.1.10",
         "lowercase-keys": "2.0.0",
         "p-cancelable": "2.1.1",
-        "responselike": "^2.0.0"
+        "responselike": "2.0.1"
       }
     },
     "got-scraping": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-3.2.9.tgz",
-      "integrity": "sha512-mMTyGHnIgLeJWCQ9x6fGR0Mzp5xcos5FxZz7HTs6Ao9x3a058Le/iadlgUYTjRZ6+0R7n+2ap6/YKU4l66FUkw==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-3.2.12.tgz",
+      "integrity": "sha512-6i01LoQf853Hsa0pMHrHnCH/ZoJNtA6MHGAAGJR48RuRIYQox7uv6VVa4GgcKcIqKmGVDYGl4Et2MOG/wsL7qQ==",
       "requires": {
-        "got-cjs": "12.0.1",
-        "header-generator": "2.0.0-beta.10",
-        "http2-wrapper": "^2.1.4",
+        "got-cjs": "12.5.4",
+        "header-generator": "^2.1.3",
+        "http2-wrapper": "^2.1.11",
         "mimic-response": "^3.1.0",
-        "ow": "^0.23.0",
+        "ow": "^0.28.1",
         "quick-lru": "^5.1.1",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "header-generator": {
-          "version": "2.0.0-beta.10",
-          "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.0.0-beta.10.tgz",
-          "integrity": "sha512-yN4YCZzoAS/sE3LTj5lLy42B7zy7nxfDEU1Nt3vCjUGjlIMYB6UdNj2WJEZHP9s1Y9tp2zkdRfZg43ewZvcyOQ==",
-          "requires": {
-            "browserslist": "^4.19.1",
-            "generative-bayesian-network": "0.1.0-beta.1",
-            "ow": "^0.23.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "ow": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-          "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.0",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
+        "tslib": "^2.4.0"
       }
     },
     "graceful-fs": {
@@ -13226,6 +13618,21 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        }
       }
     },
     "has-bigints": {
@@ -13255,38 +13662,15 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
-    },
     "header-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-1.1.3.tgz",
-      "integrity": "sha512-BqbsjZJHyQVJCrqqFL9IC3VJ77VqokxLggsWk9uqSM3mEQrtyIWo2PBJ023qoYSZRa9PuOEw5Uas/xRvQbVhTg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.7.tgz",
+      "integrity": "sha512-VCQw0Xk0gc2CcNj+3qWv1FBpaPxTWUdvB8dzeidMP8pw/5PDZVPatAqLMFPkotkk4eoTOn7GWh5z2N1B1CGn4Q==",
       "requires": {
-        "generative-bayesian-network": "0.1.0-beta.1",
-        "ow": "^0.23.0"
-      },
-      "dependencies": {
-        "ow": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/ow/-/ow-0.23.1.tgz",
-          "integrity": "sha512-tU9NCFp5bFTPf4FytkimLv0RE2ej20R2HPgk6ZMgBg4yuERKxqjPMk0OXZbbX5vnB6k1TXL4qKJqhRTkUBtGPA==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "callsites": "^3.1.0",
-            "dot-prop": "^6.0.1",
-            "lodash.isequal": "^4.5.0",
-            "type-fest": "^1.2.0",
-            "vali-date": "^1.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
+        "browserslist": "^4.21.1",
+        "generative-bayesian-network": "^2.1.7",
+        "ow": "^0.28.1",
+        "tslib": "^2.4.0"
       }
     },
     "html-encoding-sniffer": {
@@ -13304,21 +13688,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
-        }
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
       }
     },
     "http-cache-semantics": {
@@ -13337,9 +13714,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
-      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -13359,14 +13736,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "requires": {
-        "ms": "^2.0.0"
-      }
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -13409,7 +13778,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
       "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-      "dev": true,
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -13434,11 +13802,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "8.2.0",
@@ -13685,11 +14048,6 @@
       "requires": {
         "call-bind": "^1.0.0"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -15223,9 +15581,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -15322,8 +15680,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -15335,11 +15692,10 @@
       }
     },
     "keyv": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
-      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "requires": {
-        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -15391,7 +15747,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -15480,6 +15836,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -15557,29 +15914,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -15606,31 +15942,11 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-      "requires": {
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -15668,9 +15984,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -15692,17 +16008,6 @@
         "path-key": "^3.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -15711,20 +16016,10 @@
         "boolbase": "^1.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
-    },
     "nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -15877,23 +16172,15 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "ow": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.1.tgz",
-      "integrity": "sha512-1EZTywPZeUKac9gD7q8np3Aj+V54kvfIcjNEVNDSbG2Ys5xA5foW2HquvMMqgyWGLqIFMlc0Iq/HmyMHqN48sA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.2.tgz",
+      "integrity": "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==",
       "requires": {
         "@sindresorhus/is": "^4.2.0",
         "callsites": "^3.1.0",
         "dot-prop": "^6.0.1",
         "lodash.isequal": "^4.5.0",
-        "type-fest": "^2.3.4",
         "vali-date": "^1.0.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.18.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-          "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw=="
-        }
       }
     },
     "p-cancelable": {
@@ -15948,6 +16235,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parent-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
+      "integrity": "sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ=="
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -15966,11 +16258,22 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
       "requires": {
-        "parse5": "^6.0.1"
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        }
       }
     },
     "path-exists": {
@@ -16033,26 +16336,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -16101,11 +16384,6 @@
         "kleur": "3.0.3"
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -16121,10 +16399,20 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proxy-chain": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.0.5.tgz",
-      "integrity": "sha512-rTPAV0P9dCFoR3tV23cQIT3K6DfBQUh69n2Cvy3RqYFX4zegrIhWAbpVoffJaMFvoPHIIGKG0WcKQapKCjpZuQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.2.0.tgz",
+      "integrity": "sha512-kUzDckuWeZe8TiP2q872BzPKchiylEf2Hgy6knC2yIEKtAT592NkzQjMRLi+CxjDZSWrcXTFTPw/0WbpfdDiCA==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -16133,11 +16421,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "psl": {
       "version": "1.8.0",
@@ -16185,28 +16468,15 @@
         }
       }
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
-        }
-      }
     },
     "react-is": {
       "version": "17.0.2",
@@ -16235,6 +16505,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -16254,7 +16529,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
       }
@@ -16262,8 +16536,7 @@
     "resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
     "resolve.exports": {
       "version": "1.1.0",
@@ -16289,9 +16562,9 @@
       }
     },
     "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -16307,24 +16580,18 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "rxjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "requires": {
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-stable-stringify": {
       "version": "2.3.1",
@@ -16354,11 +16621,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -16390,36 +16652,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-    },
-    "simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "requires": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-          "requires": {
-            "mimic-response": "^2.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-        }
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -16507,9 +16739,9 @@
       }
     },
     "stream-json": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.4.tgz",
-      "integrity": "sha512-ja2dde1v7dOlx5/vmavn8kLrxvNfs7r2oNc5DYmNJzayDDdudyCSuTB1gFjH4XBVTIwxiMxL4i059HX+ZiouXg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.5.tgz",
+      "integrity": "sha512-NSkoVduGakxZ8a+pTPUlcGEeAGQpWL9rKJhOFCV+J/QtdQUEU5vtBgVg6eJXn8JB8RZvpbJWZGvXkhz70MLWoA==",
       "requires": {
         "stream-chain": "^2.2.5"
       }
@@ -16636,19 +16868,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      }
-    },
     "tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -16727,6 +16946,19 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
+    "tldts": {
+      "version": "5.7.104",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.104.tgz",
+      "integrity": "sha512-PlziEIVPH/ogbqOhS35K6MOeD09rd9U5g2NHO5n9NZeMC1PGpXgsjQpoJ1KiRnjhZsWDkzN8EoX3xQZuz5ZyFQ==",
+      "requires": {
+        "tldts-core": "^5.7.104"
+      }
+    },
+    "tldts-core": {
+      "version": "5.7.104",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.104.tgz",
+      "integrity": "sha512-8vhSgc2nzPNT0J7XyCqcOtQ6+ySBn+gsPmj5h95YytIZ7L2Xl40paUmj0T6Uko42HegHGQxXieunHIQuABWSmQ=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -16757,19 +16989,20 @@
       }
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "dependencies": {
         "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
         }
       }
     },
@@ -16816,17 +17049,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -16878,15 +17103,19 @@
         "through": "^2.3.8"
       }
     },
-    "underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
-    },
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -16897,29 +17126,13 @@
         "punycode": "^2.1.0"
       }
     },
-    "useragent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
-        }
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -16955,7 +17168,7 @@
     "vali-date": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+      "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg=="
     },
     "validator": {
       "version": "13.7.0",
@@ -17044,14 +17257,6 @@
         "is-symbol": "^1.0.3"
       }
     },
-    "wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "winston": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
@@ -17138,6 +17343,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {
@@ -17172,26 +17378,86 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yargonaut": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/yargonaut/-/yargonaut-1.1.4.tgz",
+      "integrity": "sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==",
+      "requires": {
+        "chalk": "^1.1.1",
+        "figlet": "^1.1.1",
+        "parent-require": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+        }
+      }
     },
     "yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "index.js",
   "version": "1.0.0",
   "dependencies": {
-    "apify": "^2.3.2",
     "axe-core": "^4.4.1",
     "axios": "^0.25.0",
+    "crawlee": "^3.1.4",
     "fs-extra": "^10.0.0",
     "inquirer": "^8.2.0",
     "jsdom": "^19.0.0",

--- a/utils.js
+++ b/utils.js
@@ -83,9 +83,9 @@ exports.getCurrentTime = () =>
 
 exports.setHeadlessMode = isHeadless => {
   if (isHeadless) {
-    process.env.APIFY_HEADLESS = 1;
+    process.env.CRAWLEE_HEADLESS = 1;
   } else {
-    process.env.APIFY_HEADLESS = 0;
+    process.env.CRAWLEE_HEADLESS = 0;
   }
 };
 


### PR DESCRIPTION
- Removed all APIs/references to Apify SDK in the code, and changed them to use Crawlee's instead
- Also addresses issue with PH scanning websites not in the domain of the given site when it is run in website mode
- Edited README to reflect the new tech stack (change Apify SDK to Crawlee)