### PR TITLE
Implement Playwright recorder custom flow script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test*.js
 coverage/
 .cache-require-paths.json
 **/errors.txt
+generatedScript*.js

--- a/constants/common.js
+++ b/constants/common.js
@@ -10,7 +10,6 @@ import fs from 'fs';
 import constants from './constants.js';
 import { consoleLogger, silentLogger } from '../logs.js';
 import * as https from 'https';
-import { isWhitelistedContentType } from '../utils.js';
 
 const document = new JSDOM('').window;
 
@@ -75,6 +74,7 @@ export const isFileSitemap = filePath => {
 export const getUrlMessage = scanner => {
   switch (scanner) {
     case constants.scannerTypes.website:
+    case constants.scannerTypes.customFlow:
       return 'Please enter URL of website: ';
     case constants.scannerTypes.sitemap:
       return 'Please enter URL or file path to sitemap, or drag and drop a sitemap file here: ';
@@ -184,8 +184,16 @@ export const prepareData = (scanType, argv) => {
   if (isEmptyObject(argv)) {
     throw Error('No inputs should be provided');
   }
-  const { scanner, url, deviceChosen, customDevice, viewportWidth, maxpages, isLocalSitemap, finalUrl } =
-    argv;
+  const {
+    scanner,
+    url,
+    deviceChosen,
+    customDevice,
+    viewportWidth,
+    maxpages,
+    isLocalSitemap,
+    finalUrl,
+  } = argv;
 
   let data;
   if (scanType === constants.scannerTypes.sitemap || scanType === constants.scannerTypes.website) {
@@ -200,18 +208,13 @@ export const prepareData = (scanType, argv) => {
     };
   }
 
-  if (scanType === constants.scannerTypes.login) {
+  if (scanType === constants.scannerTypes.customFlow) {
     data = {
-      type: argv.scanner,
+      type: scanner,
       url,
       deviceChosen,
       customDevice,
       viewportWidth,
-      loginID: argv.username,
-      loginPW: argv.userPassword,
-      idSelector: argv.usernameField,
-      pwSelector: argv.passwordField,
-      submitSelector: argv.submitBtnField,
     };
   }
   return data;
@@ -239,10 +242,10 @@ export const getLinksFromSitemap = async (sitemapUrl, maxLinksCount) => {
     }
   };
 
-  const processNonStandardSitemap = (data) => {
+  const processNonStandardSitemap = data => {
     const urlsFromData = crawlee.extractUrls({ string: data }).slice(0, maxLinksCount);
     urlsFromData.forEach(url => urls.add(url));
-  }
+  };
 
   const fetchUrls = async url => {
     let data;
@@ -262,7 +265,7 @@ export const getLinksFromSitemap = async (sitemapUrl, maxLinksCount) => {
     // Root element
     const root = $(':root')[0];
 
-    const xmlns = root.attribs?.xmlns;
+    const { xmlns } = root.attribs;
     const xmlFormatNamespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
 
     let sitemapType;

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -11,13 +11,14 @@ const maxRequestsPerCrawl = 100;
 export const axeScript = 'node_modules/axe-core/axe.min.js';
 
 const urlsCrawledObj = {
+  toScan: [],
   scanned: [],
   invalid: [],
   outOfDomain: [],
 };
 
 const scannerTypes = {
-  login: 'login',
+  customFlow: 'custom flow',
   sitemap: 'sitemap',
   website: 'website',
 };

--- a/constants/questions.js
+++ b/constants/questions.js
@@ -1,4 +1,10 @@
-import { checkUrl, getUrlMessage, isFileSitemap, isValidHttpUrl, sanitizeUrlInput } from './common.js';
+import {
+  checkUrl,
+  getUrlMessage,
+  isFileSitemap,
+  isValidHttpUrl,
+  sanitizeUrlInput,
+} from './common.js';
 import constants from './constants.js';
 
 // const isLoginScan = (answers) => {
@@ -11,7 +17,11 @@ const questions = [
     type: 'list',
     name: 'scanner',
     message: 'What would you like to scan today?',
-    choices: [constants.scannerTypes.sitemap, constants.scannerTypes.website],
+    choices: [
+      constants.scannerTypes.sitemap,
+      constants.scannerTypes.website,
+      constants.scannerTypes.customFlow,
+    ],
   },
   {
     type: 'confirm',
@@ -78,9 +88,9 @@ const questions = [
       }
       return 'Cannot resolve URL. Please provide a valid URL.';
     },
-    filter: (input) => {
-      return sanitizeUrlInput(input.trim()).url
-    }
+    filter: input => {
+      return sanitizeUrlInput(input.trim()).url;
+    },
   },
 ];
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import { cleanUp, setHeadlessMode } from './utils.js';
 import { prepareData, messageOptions } from './constants/common.js';
 import questions from './constants/questions.js';
 import combineRun from './combine.js';
+import playwrightAxeGenerator from './playwrightAxeGenerator.js';
 import constants from './constants/constants.js';
 
 // Delete dataset and request queues
@@ -34,45 +35,61 @@ exec('git branch --show-current', (err, stdout) => {
         borderColor: 'magenta',
       },
     );
-
-    let data = {};
-    let screenToScan = 'Desktop';
-
-    inquirer.prompt(questions).then(async answers => {
-      if (!answers.isHeadless) {
-        setHeadlessMode(false);
-      } else {
-        setHeadlessMode(true);
-      }
-
-      const today = new Date();
-      const yyyy = today.getFullYear();
-      const mm = String(today.getMonth() + 1).padStart(2, '0');
-      const dd = String(today.getDate()).padStart(2, '0');
-      const curHour = today.getHours() < 10 ? '0' + today.getHours() : today.getHours();
-      const curMinute = today.getMinutes() < 10 ? '0' + today.getMinutes() : today.getMinutes();
-      const domain = answers.isLocalSitemap ? 'custom' : new URL(answers.url).hostname;
-
-      data = prepareData(answers.scanner, answers);
-
-      if (answers.deviceChosen === 'Mobile') {
-        screenToScan = 'Mobile';
-      } else if (answers.deviceChosen === 'Custom') {
-        if (answers.customDevice === 'Specify viewport') {
-          screenToScan = 'Mobile';
-        } else {
-          screenToScan = answers.customDevice;
-        }
-      }
-
-      data.randomToken =
-        `PHScan_${domain}_${yyyy}${mm}${dd}_${curHour}${curMinute}_${screenToScan}`.replace(
-          /[- )(]/g,
-          '',
-        );
-
-      printMessage(['Scanning website...'], messageOptions);
-      await combineRun(data);
-    });
   }
+
+  let data = {};
+  let screenToScan;
+
+  inquirer.prompt(questions).then(async answers => {
+    if (!answers.isHeadless) {
+      setHeadlessMode(false);
+    } else {
+      setHeadlessMode(true);
+    }
+
+    data = prepareData(answers.scanner, answers);
+
+    switch (answers.deviceChosen) {
+      case 'Desktop':
+        screenToScan = answers.scanner === 'custom flow' ? 'Custom_Flow_Desktop' : 'Desktop';
+        break;
+      case 'Mobile':
+        screenToScan = answers.scanner === 'custom flow' ? 'Custom_Flow_Mobile' : 'Mobile';
+        break;
+      default:
+        if (answers.customDevice === 'Specify viewport') {
+          screenToScan =
+            answers.scanner === 'custom flow'
+              ? `Custom_Flow_CustomWidth_${answers.viewportWidth}px`
+              : `CustomWidth_${answers.viewportWidth}px`;
+        } else {
+          screenToScan =
+            answers.scanner === 'custom flow'
+              ? `Custom_Flow_${answers.customDevice}`
+              : answers.customDevice;
+        }
+    }
+
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    const curHour = today.getHours() < 10 ? '0' + today.getHours() : today.getHours();
+    const curMinute = today.getMinutes() < 10 ? '0' + today.getMinutes() : today.getMinutes();
+    const domain = new URL(answers.url).hostname;
+
+    data.randomToken =
+      `PHScan_${domain}_${yyyy}${mm}${dd}_${curHour}${curMinute}_${screenToScan}`.replace(
+        /[- )(]/g,
+        '',
+      );
+
+    printMessage(['Scanning website...'], messageOptions);
+
+    if (answers.scanner === 'custom flow') {
+      playwrightAxeGenerator(domain, data.randomToken, answers);
+    } else {
+      await combineRun(data, screenToScan);
+    }
+  });
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "inquirer": "^9.1.4",
     "jsdom": "^21.0.0",
     "mustache": "^4.2.0",
+    "playwright": "^1.27.1",
     "print-message": "^3.0.1",
     "puppeteer": "^19.5.2",
     "validator": "^13.7.0",
@@ -29,8 +30,7 @@
     "prettier": "^2.8.2"
   },
   "overrides": {
-    "node-fetch": "^3.3.0",
-    "json5": "^2.2.3"
+    "node-fetch": "^3.3.0"
   },
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest"

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -1,0 +1,207 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import readline from 'readline';
+
+const playwrightAxeGenerator = async (domain, randomToken, answers) => {
+  const { isHeadless, deviceChosen, customDevice, customWidth } = answers;
+  const block1 = `import { chromium, devices, webkit } from "playwright";
+import { createCrawleeSubFolders, runAxeScript } from "./crawlers/commonCrawlerFunc.js";
+import { generateArtifacts } from './mergeAxeResults.js';
+import { createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
+import constants from "./constants/constants.js";
+
+process.env.CRAWLEE_STORAGE_DIR = constants.a11yStorage;
+
+const scanDetails = {
+    startTime: new Date().getTime(),
+    crawlType: 'Custom Flow',
+    requestUrl: '${domain}',
+};
+    
+const urlsCrawled = { ...constants.urlsCrawledObj };
+const { dataset } = await createCrawleeSubFolders('${randomToken}');
+const runAxeScan = async (page) => {
+  const host = new URL(page.url()).hostname;
+  const result = await runAxeScript(page, host);
+  await dataset.pushData(result);
+  urlsCrawled.scanned.push(page.url());
+}`;
+
+  const block2 = `  return urlsCrawled;
+        })().then(async (urlsCrawled) => {
+            scanDetails.endTime = new Date().getTime();
+            scanDetails.urlsCrawled = urlsCrawled;
+            await createDetailsAndLogs(scanDetails, '${randomToken}');
+            await createAndUpdateResultsFolders('${randomToken}');
+            await generateArtifacts('${randomToken}', 'Automated Scan');
+        });`;
+
+  let tmpDir;
+  const appPrefix = 'purple-hats';
+
+
+  try {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), appPrefix));
+
+    if (customDevice === 'iPhone 11') {
+      execSync(
+        `npx playwright codegen --target javascript -o ${tmpDir}/intermediateScript.js ${domain} --device='iPhone 11'`,
+      );
+    } else if (customDevice === 'Samsung Galaxy S9+') {
+      execSync(
+        `npx playwright codegen --target javascript -o ${tmpDir}/intermediateScript.js ${domain} --device='Galaxy S9+'`,
+      );
+    } else if (customDevice === 'Specify viewport') {
+      execSync(
+        `npx playwright codegen --target javascript -o ${tmpDir}/intermediateScript.js ${domain} --viewport-size=${viewportWidth},720`,
+      );
+    } else {
+      execSync(
+        `npx playwright codegen --target javascript -o ${tmpDir}/intermediateScript.js ${domain}`,
+      );
+    }
+
+    const fileStream = fs.createReadStream(`${tmpDir}/intermediateScript.js`);
+
+    const rl = readline.createInterface({
+      input: fileStream,
+      crlfDelay: Infinity,
+    });
+
+    const generatedScript = `./generatedScript-${randomToken}.js`;
+
+    const appendToGeneratedScript = data => {
+      fs.appendFileSync(generatedScript, `${data}\n`);
+    };
+
+    let firstGoToUrl = false;
+
+    for await (let line of rl) {
+      if (
+        line.trim() === `const { chromium } = require('playwright');` ||
+        line.trim() === `const { chromium, devices } = require('playwright');` ||
+        line.trim() === `const { webkit, devices } = require('playwright');`
+      ) {
+        appendToGeneratedScript(block1);
+        continue;
+      }
+      if (line.trim() === `headless: false` && isHeadless) {
+        appendToGeneratedScript(`headless: true`);
+        continue;
+      }
+      //check if more than 1 element located
+      if (line.trim().includes('getBy')) {
+        const lastIndex = line.lastIndexOf('.');
+        const locator = line.substring(0, lastIndex);
+        appendToGeneratedScript(
+          ` (${locator}.count()>1)? [console.log('Please re-click the intended DOM element'), page.setDefaultTimeout(0)]:
+          ${line}
+        `,
+        );
+        continue;
+      }
+      if (line.trim() === `const page = await context.newPage();`) {
+        if (deviceChosen === 'Mobile') {
+          appendToGeneratedScript(line);
+          appendToGeneratedScript(
+            `  const pageHeight = page.viewportSize().height
+            await page.setViewportSize({
+                      width: 360,
+                      height: pageHeight,
+                      isMobile: true,
+                    });`,
+          );
+        } else if (customWidth) {
+          appendToGeneratedScript(line);
+          appendToGeneratedScript(
+            `const pageHeight = page.viewportSize().height
+            await page.setViewportSize({
+            width: ${customWidth},
+            height: pageHeight,
+            isMobile: true,
+          });`,
+          );
+        } else {
+          appendToGeneratedScript(line);
+        }
+        continue;
+      }
+      if (line.trim().includes(`/common/login?spcptracking`)) {
+        appendToGeneratedScript(
+          `await page.goto('https://iam.hdb.gov.sg/common/login', { waitUntil: 'networkidle' });`,
+        );
+        continue;
+      }
+      if (line.trim().includes(`spauthsuccess?code=`)) {
+        continue;
+      }
+      if (line.trim().startsWith(`await page.goto(`)) {
+        if (!firstGoToUrl) {
+          firstGoToUrl = true;
+          appendToGeneratedScript(line);
+        } else {
+            appendToGeneratedScript(
+            line.replace('goto', 'waitForURL').replace(')', ', {timeout: 60000})'),
+            );
+
+            if (fs.existsSync('exclusions.txt')) {
+                const whitelistedDomains = fs.readFileSync('exclusions.txt').toString().split("\n");
+        
+                let isWhitelisted = whitelistedDomains.filter(function(pattern){
+                    return new RegExp(pattern).test(line)
+                })
+
+                if (isWhitelisted.length > 0){
+                    continue;
+                }
+            };
+        }
+        appendToGeneratedScript(` await runAxeScan(page);`);
+        continue;
+      }
+      if (line.trim().startsWith(`await page.waitForURL(`)) {
+        appendToGeneratedScript(line);
+
+        if (fs.existsSync('exclusions.txt')) {
+            const whitelistedDomains = fs.readFileSync('exclusions.txt').toString().split("\n");
+    
+            let isWhitelisted = whitelistedDomains.filter(function(pattern){
+                return new RegExp(pattern).test(line)
+            })
+
+            if (isWhitelisted.length > 0){
+                continue;
+            }
+        };
+        appendToGeneratedScript(` await runAxeScan(page);`);
+        continue;
+      }
+      if (line.trim() === `await browser.close();`) {
+        appendToGeneratedScript(line);
+        appendToGeneratedScript(block2);
+        break;
+      }
+      appendToGeneratedScript(line);
+    }
+
+    import(generatedScript);
+  } catch (e) {
+    console.error(`Error: ${e}`);
+  } finally {
+    try {
+      if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    } catch (e) {
+      console.error(
+        `An error has occurred while removing the temp folder at ${tmpDir}. Please remove it manually. Error: ${e}`,
+      );
+    }
+  }
+
+  // fs.unlinkSync(generatedScript);
+};
+
+export default playwrightAxeGenerator;


### PR DESCRIPTION
- Integrated with current terminal options by providing 'custom flow' option
- Allow user to set device or custom viewport width
- Allow user to perform MFA by delaying timeout to 60 seconds
- Inform user in terminal to re-click intended DOM element when DOM element is not found (in the case of dynamic/responsive web pages)
- Save intermediate script in tmpdir of user's system
- Read lines from exclusion.txt for user to specify URLs to skip axe scan
- Implemented similar file naming structure as results for generatedScript