### PR TITLE
Extend website scan coverage for JS-based actions by Clicking Elements

### DIFF
--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -52,7 +52,7 @@ export const createCrawleeSubFolders = async randomToken => {
 
 export const preNavigationHooks = [
   async (_crawlingContext, gotoOptions) => {
-    gotoOptions = { waitUntil: 'networkidle2', timeout: 30000 };
+    gotoOptions = { waitUntil: "domcontentloaded", timeout: 30000 };
   },
 ];
 

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -64,15 +64,16 @@ const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequests
         urlsCrawled.scanned.push(currentUrl);
 
         await enqueueLinksByClickingElements({
-          // set selector matches non-anchor elements, click where element 
+          // set selector matches non-anchor elements, click where element
           // NOT <a> or [type="submit"] or [type="reset"]
           // IS role='link' or onclick or button.*link
+          // enqueue new page URL
           selector: ':not(a, [type="submit"], [type="reset"]):is([role="link"], [onclick], button.*link)',
           requestQueue,
         });
 
         await enqueueLinks({
-          // set selector matches non-anchor elements, queue hyperlink contained in <a>
+          // set selector matches anchor elements, and enqueue hyperlink contained in <a>
           selector: 'a',
           strategy: 'same-domain',
           requestQueue,


### PR DESCRIPTION
- Use Crawlee `enqueueLinksByClickingElements` to navigate pages by Clicking Elements which matches non-anchor elements where element 
  - not `<a>` or `[type="submit"]` or `[type="reset"]`
  - is `role='link'` or `onclick` or `button.*link`

- Set `preNavigationHooks` `gotoOptions` to `waitUntil: domcontentloaded`
          