### PR TITLE
Bug fixes for results zipping in cli mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import _yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import printMessage from 'print-message';
-import { cleanUp, zipResults, setHeadlessMode, setThresholdLimits, getVersion } from './utils.js';
+import { cleanUp, zipResults, setHeadlessMode, setThresholdLimits, getVersion, getStoragePath } from './utils.js';
 import { exec, execSync } from 'child_process';
 import { checkUrl, prepareData, isValidHttpUrl, isFileSitemap } from './constants/common.js';
 
@@ -167,22 +167,19 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
 
     printMessage([`Version: ${appVersion}-${branchName}`, 'Scanning website...'], messageOptions);
     await combineRun(data, deviceToScan);
-    return `PHScan_${domain}_${yyyy}${mm}${dd}_${curHour}${curMinute}_${argvs.customDevice}`;
+    return getStoragePath(data.randomToken);
   };
 
   scanInit(options).then(async storagePath => {
-    // Path to scan result
-    storagePath = fs.readdirSync('results').filter(fn => fn.startsWith(storagePath));
-
     // Take option if set
     if (typeof options.zip === 'string') {
       constants.cliZipFileName = options.zip;
     }
 
     await fs
-      .ensureDir(`results/${storagePath[0]}`)
+      .ensureDir(storagePath)
       .then(async () => {
-        await zipResults(constants.cliZipFileName, `results/${storagePath[0]}`);
+        await zipResults(constants.cliZipFileName, storagePath);
         const messageToDisplay = [`Report of this run is at ${constants.cliZipFileName}`];
 
         if (process.env.REPORT_BREAKDOWN === '1') {


### PR DESCRIPTION
This PR fixes two bugs with regards to zipping of scan results in CLI mode:
1. Results zip not being created when scanning with a custom viewport width (i.e. using the `-w` flag).
2. Wrong results folder may be zipped when running two scans on the same URL in quick succession.
    - Example occurrence:
        - First run `node cli.js -c sitemap -u https://www.tech.gov.sg/sitemap.xml -p 1`.
        - After the scan is complete, immediately run `node cli.js -c sitemap -u https://www.tech.gov.sg/sitemap.xml -p 20`. This scan must be done in the same minute as the previous scan.
        - The results zip at the end of the second scan will be created using the results from the first scan, which is incorrect behaviour.

PR Checklist:
- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests **(N.A., manual testing is done instead)**
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions (**N.A., no dependencies added/updated)**

