### PR TITLE
Fix bug with validation of d and w flags in cli mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -66,7 +66,7 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     })
     .coerce('d', option => {
       const deviceString = constants.devices.includes(option);
-      if (option && !deviceString) {
+      if (!deviceString) {
         printMessage(
           [`Invalid device. Please provide an existing device to start the scan.`],
           messageOptions,
@@ -76,7 +76,7 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
       return option;
     })
     .coerce('w', option => {
-      if (Number.isNaN(option)) {
+      if (!option || Number.isNaN(option)) {
         printMessage([`Invalid viewport width. Please provide a number. `], messageOptions);
         process.exit(1);
       } else if (option < 320 || option > 1080) {


### PR DESCRIPTION
This PR addresses the issue with the CLI accepting empty inputs for both the d and w flags, which is not proper behaviour.

PR Checklist:
- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests **(N.A., manual testing is done instead)**
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions (**N.A., no dependencies added/updated)**