### PR TITLE
Show viewport in custom scan

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -75,7 +75,7 @@ const combineRun = async (details, deviceToScan) => {
 
   if (scanDetails.urlsCrawled.scanned.length > 0) {
     await createAndUpdateResultsFolders(randomToken);
-    await generateArtifacts(randomToken, url, deviceToScan);
+    await generateArtifacts(randomToken, url, type, deviceToScan);
   } else {
     printMessage([`No pages were scanned.`], constants.alertMessageOoptions);
   }

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -224,13 +224,14 @@ const flattenAndSortResults = allIssues => {
   allIssues.wcagViolations = Array.from(allIssues.wcagViolations);
 };
 
-export const generateArtifacts = async (randomToken, urlScanned, viewport) => {
+export const generateArtifacts = async (randomToken, urlScanned, scanType, viewport) => {
   const storagePath = getStoragePath(randomToken);
 
   const directory = `${storagePath}/${constants.allIssueFileName}`;
   const allIssues = {
     startTime: getCurrentTime(),
     urlScanned,
+    scanType,
     viewport,
     totalPagesScanned: 0,
     totalItems: 0,

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -247,7 +247,7 @@ const processPage = async page => {
             await createDetailsAndLogs(scanDetails, '${randomToken}');
             await createAndUpdateResultsFolders('${randomToken}');
             createScreenshotsFolder('${randomToken}');
-            await generateArtifacts('${randomToken}', '${domain}','Automated Scan');
+            await generateArtifacts('${randomToken}', '${domain}', 'Customized', '${viewportWidth ? `CustomWidth_${viewportWidth}px` : customDevice ? customDevice : deviceChosen ? deviceChosen : 'Desktop' }');
         });`;
 
   let tmpDir;

--- a/static/ejs/partials/components/scanAbout.ejs
+++ b/static/ejs/partials/components/scanAbout.ejs
@@ -34,7 +34,7 @@
         fill="#CED4DA"
       />
     </svg>
-    <a href="<%= urlScanned %>" target="_blank"><%= urlScanned %></a>
+    <a aria-label="URL Scanned" href="<%= urlScanned %>" target="_blank"><%= urlScanned %></a>
   </div>
   <div>
     <% if (viewport.startsWith('Desktop')) { %>
@@ -84,10 +84,11 @@
       />
     </svg>
     <% } %>
-    <span
-      ><%= viewport.startsWith("CustomWidth") ? `${viewport.split("_")[1]} width` : viewport %>
-      <%= viewport === 'Automated Scan' ? '' : 'viewport' %></span
->
+    <span>
+      <%= viewport.startsWith("CustomWidth") ? `${viewport.split("_")[1]} width` : viewport %>
+      viewport
+      <%= scanType === 'Customized' ? '(customized scan)' : '' %>
+    </span>
   </div>
   <div>
     <svg

--- a/static/ejs/partials/components/wcagCompliance.ejs
+++ b/static/ejs/partials/components/wcagCompliance.ejs
@@ -61,7 +61,7 @@ parseFloat((Object.keys(wcagLinks).length - wcagViolations.length) / Object.keys
       >WCAG 2.1</a
     >
     (Conformance Level A & AA) Success Criteria can be automatically checked so
-    <a href="#" target="_blank">manual testing</a>
+    <a aria-label="Manual testing guide" href="http://go.gov.sg/a11y-manual-testing" target="_blank">manual testing</a>
     is still required.
   </p>
 </div>

--- a/static/ejs/partials/footer.ejs
+++ b/static/ejs/partials/footer.ejs
@@ -1,4 +1,4 @@
-<div id="footer" class="card">
+<footer aria-label="Report footer" id="footer" class="card">
   <div class="row mx-0">
     <div class="col-sm-6 text-sm-start">
       <a href="mailto:enquiries_HATS@tech.gov.sg">Help us improve</a>
@@ -11,4 +11,4 @@
       >
     </div>
   </div>
-</div>
+</footer>

--- a/static/ejs/partials/header.ejs
+++ b/static/ejs/partials/header.ejs
@@ -1,4 +1,4 @@
-<div id="header">
+<header aria-label="Report header" id="header">
   <div class="z-2 card flex-row justify-content-between px-3 py-4">
     <div class="d-flex align-items-center">
       <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -34,4 +34,4 @@
       </label>
     </div> %>
   </div>
-</div>
+</header>

--- a/static/ejs/partials/main.ejs
+++ b/static/ejs/partials/main.ejs
@@ -1,4 +1,4 @@
-<div class="d-flex flex-grow-1 align-items-stretch">
+<main aria-label="Report main content" class="d-flex flex-grow-1 align-items-stretch">
   <%- include("components/scanAbout") %>
   <div class="d-flex flex-column flex-grow-1">
     <div class="row m-0 py-4 px-3">
@@ -19,4 +19,4 @@
     <%- include("components/ruleOffcanvas") %>
     <%- include("footer") %>
   </div>
-</div>
+</main>


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Showing of viewport in the HTML report for custom scans
- Replaced the href of the manual testing link in the report with a live link
- Miscellaneous accessibility improvements in the report

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests **(N.A.)**
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions **(N.A)**
