### PR TITLE
Various scan improvements and re-implement scan results

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -2,7 +2,7 @@
 import {jest} from '@jest/globals'
 import {
   setThresholdLimits,
-  getHostnameFromRegex,
+  getHost,
   getCurrentDate,
   validateUrl,
   getStoragePath,
@@ -33,13 +33,16 @@ describe('test setting of threshold warn level', () => {
   });
 });
 
-describe('test getHostnameFromRegex', () => {
+describe('test getHost', () => {
   test('should retrieve the hostnames accordingly', () => {
-    expect(getHostnameFromRegex('https://www.bbc.com/news')).toEqual('www.bbc.com');
-    expect(getHostnameFromRegex('https://www.isomer.gov.sg/')).toEqual('www.isomer.gov.sg');
-    expect(getHostnameFromRegex('https://fontawesome.com/sessions/sign-in')).toEqual(
+    expect(getHost('https://www.bbc.com/news')).toEqual('www.bbc.com');
+    expect(getHost('https://www.isomer.gov.sg/')).toEqual('www.isomer.gov.sg');
+    expect(getHost('https://fontawesome.com/sessions/sign-in')).toEqual(
       'fontawesome.com',
     );
+    // port number will be excluded since it is the default port for HTTPS
+    expect(getHost('https://www.crowdtask.gov.sg:443')).toEqual('www.crowdtask.gov.sg');
+    expect(getHost('http://localhost:5000/about/me')).toEqual('localhost:5000');
   });
 });
 

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ import {
   getStoragePath,
 } from './utils.js';
 import { checkUrl, prepareData, isFileSitemap } from './constants/common.js';
-import { cliOptions, messageOptions, configureReportSetting } from './constants/cliFunctions.js';
+import { cliOptions, messageOptions } from './constants/cliFunctions.js';
 import constants from './constants/constants.js';
 import combineRun from './combine.js';
 import playwrightAxeGenerator from './playwrightAxeGenerator.js';
@@ -110,12 +110,6 @@ const scanInit = async argvs => {
   argvs.scanner = constants.scannerTypes[argvs.scanner];
   argvs.headless = argvs.headless === 'yes';
 
-  // Set the parameters required to indicate whether to break down report
-  configureReportSetting(argvs.reportbreakdown);
-
-  // Set the parameters required to indicate threshold limits
-  setThresholdLimits(argvs.warn);
-
   const res = await checkUrl(argvs.scanner, argvs.url);
   const statuses = constants.urlCheckStatuses;
   switch (res.status) {
@@ -124,12 +118,6 @@ const scanInit = async argvs => {
       break;
     case statuses.cannotBeResolved.code:
       printMessage([statuses.cannotBeResolved.message], messageOptions);
-      process.exit(res.status);
-    case statuses.errorStatusReceived.code:
-      printMessage(
-        [`${statuses.errorStatusReceived.message}${res.serverResponse}.`],
-        messageOptions,
-      );
       process.exit(res.status);
     case statuses.systemError.code:
       printMessage([statuses.systemError.message], messageOptions);
@@ -193,13 +181,13 @@ const scanInit = async argvs => {
     await combineRun(data, screenToScan);
   }
 
+  // Delete dataset and request queues
+  cleanUp(data.randomToken);
+
   return getStoragePath(data.randomToken);
 };
 
 scanInit(options).then(async storagePath => {
-  // Delete dataset and request queues
-  cleanUp(constants.a11yStorage);
-
   // Take option if set
   if (typeof options.zip === 'string') {
     constants.cliZipFileName = options.zip;

--- a/combine.js
+++ b/combine.js
@@ -5,13 +5,11 @@ import crawlDomain from './crawlers/crawlDomain.js';
 
 import { generateArtifacts } from './mergeAxeResults.js';
 import {
-  getHostnameFromRegex,
+  getHost,
   createAndUpdateResultsFolders,
   createDetailsAndLogs,
 } from './utils.js';
 import constants from './constants/constants.js';
-
-process.env.CRAWLEE_STORAGE_DIR = constants.a11yStorage;
 
 const combineRun = async (details, deviceToScan) => {
   const envDetails = { ...details };
@@ -28,8 +26,10 @@ const combineRun = async (details, deviceToScan) => {
     isLocalSitemap,
   } = envDetails;
 
+  process.env.CRAWLEE_STORAGE_DIR = randomToken;
+
   const host =
-    type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHostnameFromRegex(url);
+    type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
 
   const scanDetails = {
     startTime: new Date().getTime(),

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -61,9 +61,6 @@ if (fs.existsSync('/.dockerenv')) {
   launchOptionsArgs = ['--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage'];
 }
 
-//  _folder_paths
-const a11yStorage = '.a11y_storage';
-
 export const impactOrder = {
   minor: 0,
   moderate: 1,
@@ -79,7 +76,7 @@ const urlCheckStatuses = {
     message:
       'Provided URL cannot be accessed. Please verify your internet connectivity and the correctness of the domain.',
   },
-  errorStatusReceived: {
+  errorStatusReceived: { // unused for now
     code: 13,
     message: 'Provided URL cannot be accessed. Server responded with code ', // append it with the response code received,
   },
@@ -99,8 +96,6 @@ const xmlSitemapTypes = {
 };
 
 export default {
-  a11yStorage,
-  a11yDataStoragePath: `${a11yStorage}/datasets`,
   allIssueFileName: 'all_issues',
   cliZipFileName: 'a11y-scan-results.zip',
   maxRequestsPerCrawl,
@@ -118,8 +113,3 @@ export const wcagWebPage = 'https://www.w3.org/TR/WCAG21/';
 const latestAxeVersion = '4.4';
 export const axeVersion = latestAxeVersion;
 export const axeWebPage = `https://dequeuniversity.com/rules/axe/${latestAxeVersion}/`;
-
-export const alertMessageOptions = {
-  border: true,
-  borderColor: 'red',
-};

--- a/constants/questions.js
+++ b/constants/questions.js
@@ -74,12 +74,8 @@ const questions = [
           return true;
         case statuses.cannotBeResolved.code:
           return statuses.cannotBeResolved.message;
-        case statuses.errorStatusReceived.code:
-          return `${statuses.errorStatusReceived.message}${res.serverResponse}.`;
-
         case statuses.systemError.code:
           return statuses.systemError.message;
-
         case statuses.invalidUrl.code:
           if (answers.scanner !== constants.scannerTypes.sitemap) {
             return statuses.invalidUrl.message;

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -32,6 +32,8 @@ const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequests
     device = {};
   }
 
+  let pagesCrawled = 0;
+
   const crawler = new crawlee.PlaywrightCrawler({
     launchContext: {
       launchOptions: {
@@ -54,6 +56,11 @@ const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequests
     requestQueue,
     preNavigationHooks,
     requestHandler: async ({ page, request, enqueueLinks, enqueueLinksByClickingElements }) => {
+      if (pagesCrawled === maxRequestsPerCrawl) {
+        return;
+      }
+      pagesCrawled++;
+      
       const currentUrl = request.url;
       const location = await page.evaluate('location');
 

--- a/index.js
+++ b/index.js
@@ -57,5 +57,5 @@ inquirer.prompt(questions).then(async answers => {
     await combineRun(data, screenToScan);
   }
   // Delete dataset and request queues
-  cleanUp(constants.a11yStorage);
+  cleanUp(data.randomToken);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "purple-hats",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "purple-hats",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "ISC",
       "dependencies": {
         "axe-core": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purple-hats",
   "main": "index.js",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "imports": {
     "#root/*.js": "./*.js"

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -44,7 +44,7 @@ const playwrightAxeGenerator = async (domain, data) => {
   import { consoleLogger, silentLogger } from '#root/logs.js';
   const blacklistedPatternsFilename = 'exclusions.txt';
 
-process.env.CRAWLEE_STORAGE_DIR = constants.a11yStorage;
+process.env.CRAWLEE_STORAGE_DIR = '${randomToken}';
 const compareExe = getExecutablePath('**/ImageMagick*/bin','compare');
 
 if (!compareExe) {
@@ -291,7 +291,7 @@ const processPage = async page => {
         customDevice = 'iPhone 11';
       }
 
-      if (customDevice) {
+      if (customDevice && !viewportWidth) {
         viewportWidth = devices[customDevice].viewport.width;
         userAgentOpts = `--user-agent \"${devices[customDevice].userAgent}\"`;
       }

--- a/utils.js
+++ b/utils.js
@@ -19,12 +19,7 @@ export const getVersion = () => {
   return versionNum;
 };
 
-export const getHostnameFromRegex = url => {
-  const matches = url.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i);
-
-  // extract hostname (will be null if no match is found)
-  return matches && matches[1];
-};
+export const getHost = url => new URL(url).host
 
 export const getCurrentDate = () => {
   const date = new Date();
@@ -58,7 +53,7 @@ export const createAndUpdateResultsFolders = async randomToken => {
   const storagePath = getStoragePath(randomToken);
   await fs.ensureDir(`${storagePath}/reports`);
   await fs.copy(
-    `${constants.a11yDataStoragePath}/${randomToken}`,
+    `${randomToken}/datasets/${randomToken}`,
     `${storagePath}/${constants.allIssueFileName}`,
   );
 };


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Addresses issue with certain sites blocking non-browser user agents
- Allow scan to continue for non 2xx entry points
- Extract host correctly from URLs that contain port 443 in them to prevent Crawlee from falsely determining that a site is out of domain
- Fix bug with not being able to run a custom scan using a custom viewport width from `index.js`
- Allow concurrent scans to happen without error
- Correctly limit pages scanned in website scans
- Re-implement scan results in the CLI. Current implementation:
  ```
  ┌──────────────────────────────────────────┐
  │ Scan Summary                             │
  │                                          │
  │ Must Fix: 2 issues / 22 occurrences      │
  │ Good to Fix: 6 issues / 3619 occurrences │
  │ Passed: 32800 occurrences                │
  └──────────────────────────────────────────┘
  ```
- Remove deprecated CLI options
- Bump version from 0.0.14 to 0.0.15

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [x] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions **(N.A)**
