### PR TITLE
Implement strategy flag for website scans (CLI only)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,13 +34,13 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
   .options(cliOptions)
   .example([
     [
-      `To scan sitemap of website:', 'node cli.js -c [ 1 | ${constants.scannerTypes.sitemap} ] -d <device> -u <url_link> -w <viewportWidth>`,
+      `To scan sitemap of website:', 'node cli.js -c [ 1 | sitemap ] -u <url_link> [ -d <device> | -w <viewport_width> ]`,
     ],
     [
-      `To scan a website', 'node cli.js -c [ 2 | ${constants.scannerTypes.website} ] -d <device> -u <url_link> -w <viewportWidth>`,
+      `To scan a website', 'node cli.js -c [ 2 | website ] -u <url_link> [ -d <device> | -w <viewport_width> ]`,
     ],
     [
-      `To start a custom flow scan', 'node cli.js -c [ 3 | ${constants.scannerTypes.custom} ] -d <device> -u <url_link> -w <viewportWidth>`,
+      `To start a custom flow scan', 'node cli.js -c [ 3 | custom ] -u <url_link> [ -d <device> | -w <viewport_width> ]`,
     ],
   ])
   .coerce('c', option => {
@@ -99,7 +99,13 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
   })
   .check(argvs => {
     if (argvs.scanner === 'custom' && argvs.maxpages) {
-      throw new Error('-p or --maxpages is only available in website and sitemap scans');
+      throw new Error('-p or --maxpages is only available in website and sitemap scans.');
+    }
+    return true;
+  })
+  .check(argvs => {
+    if (argvs.scanner !== 'website' && argvs.strategy) {
+      throw new Error('-s or --strategy is only available in website scans.');
     }
     return true;
   })
@@ -109,6 +115,10 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
 const scanInit = async argvs => {
   argvs.scanner = constants.scannerTypes[argvs.scanner];
   argvs.headless = argvs.headless === 'yes';
+
+  if (argvs.scanner === constants.scannerTypes.website && !argvs.strategy) {
+    argvs.strategy = 'same-domain';
+  }
 
   const res = await checkUrl(argvs.scanner, argvs.url);
   const statuses = constants.urlCheckStatuses;

--- a/combine.js
+++ b/combine.js
@@ -4,11 +4,7 @@ import crawlSitemap from './crawlers/crawlSitemap.js';
 import crawlDomain from './crawlers/crawlDomain.js';
 
 import { generateArtifacts } from './mergeAxeResults.js';
-import {
-  getHost,
-  createAndUpdateResultsFolders,
-  createDetailsAndLogs,
-} from './utils.js';
+import { getHost, createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
 import constants from './constants/constants.js';
 
 const combineRun = async (details, deviceToScan) => {
@@ -24,12 +20,12 @@ const combineRun = async (details, deviceToScan) => {
     viewportWidth,
     maxRequestsPerCrawl,
     isLocalSitemap,
+    strategy,
   } = envDetails;
 
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
-  const host =
-    type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
+  const host = type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
 
   const scanDetails = {
     startTime: new Date().getTime(),
@@ -62,6 +58,7 @@ const combineRun = async (details, deviceToScan) => {
         host,
         viewportSettings,
         maxRequestsPerCrawl,
+        strategy,
       );
       break;
 

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -58,6 +58,13 @@ export const cliOptions = {
     default: 'yes',
     demandOption: false,
   },
+  s: {
+    alias: 'strategy',
+    describe: 'Strategy to choose which links to crawl in a website scan. Defaults to "same-domain".',
+    choices: ['same-domain', 'same-hostname'],
+    requiresArg: true,
+    demandOption: false
+  },
   reportbreakdown: {
     describe: 'Will break down the main report according to impact',
     type: 'boolean',

--- a/constants/common.js
+++ b/constants/common.js
@@ -217,6 +217,7 @@ export const prepareData = argv => {
     customDevice,
     viewportWidth,
     maxpages,
+    strategy,
     isLocalSitemap,
     finalUrl,
   } = argv;
@@ -229,6 +230,7 @@ export const prepareData = argv => {
     customDevice,
     viewportWidth,
     maxRequestsPerCrawl: maxpages || constants.maxRequestsPerCrawl,
+    strategy,
     isLocalSitemap,
   };
 };

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -9,7 +9,7 @@ import {
 } from './commonCrawlerFunc.js';
 import constants from '../constants/constants.js';
 
-const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequestsPerCrawl) => {
+const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequestsPerCrawl, strategy) => {
   const urlsCrawled = { ...constants.urlsCrawledObj };
   const { maxConcurrency } = constants;
   const { deviceChosen, customDevice, viewportWidth } = viewportSettings;
@@ -72,7 +72,7 @@ const crawlDomain = async (url, randomToken, host, viewportSettings, maxRequests
         await enqueueLinks({
           // set selector matches anchor elements with href but not contains # or starting with mailto:
           selector: 'a:not(a[href*="#"],a[href^="mailto:"])',
-          strategy: 'same-domain',
+          strategy,
           requestQueue,
           transformRequestFunction(req) {
             // ignore all links ending with `.pdf`


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Strategy flag for website scans on CLI (either same domain or same hostname)

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests **(N.A.)**
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions **(N.A.)**
