### PR TITLE
Update blackListedFileExtensions

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -81,6 +81,7 @@ describe('test validateUrl', () => {
     expect(validateUrl('https://www.bbc.ppt')).toEqual(false);
     expect(validateUrl('https://www.bbc.ico')).toEqual(false);
     expect(validateUrl('https://www.bbc.woff')).toEqual(false);
+    expect(validateURL('https://www.bbc.webp')).toEqual(false);
   });
 });
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -74,6 +74,7 @@ export const blackListedFileExtensions = [
   'woff',
   'pdf',
   'zip',
+  'webp',
 ];
 
 export const intermediateScreenshotsPath = './screenshots';


### PR DESCRIPTION
This PR adds the webp file extension to the list of blacklisted file extensions as webp is now universally supported in evergreen browsers 


<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [x] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
