### PR TITLE
Fix existing bugs with regards to crawler and added new "-f" flag

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,5 +7,6 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ Options:
   -t, --specifiedMaxConcurrency  Maximum number of pages to scan concurrently.
                                  Use for sites with throttling. Defaults to 25.
                                                                           [number]
+  -f, --needsReviewItems  Whether to display rule items requiring manual review in
+                          report. Defaults to false.
+                                                        [choices: "true", "false"]
 Examples:
   To scan sitemap of website:', 'node cli.js -c [ 1 | Sitemap ] -d <device> -u
    <url_link> -w <viewportWidth>

--- a/cli.js
+++ b/cli.js
@@ -160,8 +160,7 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return nameEmail;
   })
   .coerce('f', option => {
-    console.log('f option: ', option);
-    if (typeof option !== 'boolean') {
+    if (option !== 'true' && value !== 'false') {
       printMessage(
         [`Invalid value for needsReviewItems. Please provide boolean value(true/false).`],
         messageOptions,

--- a/cli.js
+++ b/cli.js
@@ -159,6 +159,17 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     }
     return nameEmail;
   })
+  .coerce('f', option => {
+    console.log('f option: ', option);
+    if (typeof option !== 'boolean') {
+      printMessage(
+        [`Invalid value for needsReviewItems. Please provide boolean value(true/false).`],
+        messageOptions,
+      );
+      process.exit(1);
+    }
+    return option;
+  })
   .check(argvs => {
     if (argvs.scanner === 'custom' && argvs.maxpages) {
       throw new Error('-p or --maxpages is only available in website and sitemap scans.');
@@ -298,8 +309,8 @@ const scanInit = async argvs => {
         process.exit(res.status);
       }
       /* if sitemap scan is selected, treat this URL as a filepath
-        isFileSitemap will tell whether the filepath exists, and if it does, whether the
-        file is a sitemap */
+          isFileSitemap will tell whether the filepath exists, and if it does, whether the
+          file is a sitemap */
       if (isFileSitemap(argvs.url)) {
         argvs.isLocalSitemap = true;
         break;

--- a/cli.js
+++ b/cli.js
@@ -160,7 +160,7 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return nameEmail;
   })
   .coerce('f', option => {
-    if (option !== 'true' && value !== 'false') {
+    if (!cliOptions.f.choices.includes(option)) {
       printMessage(
         [`Invalid value for needsReviewItems. Please provide boolean value(true/false).`],
         messageOptions,

--- a/combine.js
+++ b/combine.js
@@ -30,6 +30,7 @@ const combineRun = async (details, deviceToScan) => {
     needsReviewItems
   } = envDetails;
 
+  process.env.CRAWLEE_LOG_LEVEL = "ERROR"
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
   const host = type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);

--- a/combine.js
+++ b/combine.js
@@ -27,6 +27,7 @@ const combineRun = async (details, deviceToScan) => {
     userDataDirectory,
     strategy,
     specifiedMaxConcurrency,
+    needsReviewItems
   } = envDetails;
 
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
@@ -64,6 +65,7 @@ const combineRun = async (details, deviceToScan) => {
         browser,
         userDataDirectory,
         specifiedMaxConcurrency,
+        needsReviewItems
       );
       break;
 
@@ -78,6 +80,7 @@ const combineRun = async (details, deviceToScan) => {
         userDataDirectory,
         strategy,
         specifiedMaxConcurrency,
+        needsReviewItems
       );
       break;
 

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -94,6 +94,13 @@ export const cliOptions = {
     type: 'number',
     demandOption: false,
   },
+  f: {
+    alias: 'needsReviewItems',
+    describe: 'Whether to display items requiring manual review in report.',
+    type: 'string',
+    choices: ['true', 'false'],
+    demandOption: false,
+  }
 };
 
 export const configureReportSetting = isEnabled => {

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -100,7 +100,7 @@ export const cliOptions = {
     type: 'string',
     choices: ['true', 'false'],
     demandOption: false,
-  }
+  },
 };
 
 export const configureReportSetting = isEnabled => {

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -96,7 +96,7 @@ export const cliOptions = {
   },
   f: {
     alias: 'needsReviewItems',
-    describe: 'Whether to display items requiring manual review in report.',
+    describe: 'Whether to display items requiring manual review in report. Defaults to false.',
     type: 'string',
     choices: ['true', 'false'],
     demandOption: false,

--- a/constants/common.js
+++ b/constants/common.js
@@ -102,11 +102,8 @@ export const sortAlphaAttributes = htmlString => {
 };
 
 export const isBlacklistedFileExtensions = (url, blacklistedFileExtensions) => {
-  const urlExtension = url.split('.').pop(); 
-
-  const isBlacklisted = blacklistedFileExtensions.includes(urlExtension);
-
-  return isBlacklisted;
+  const urlExtension = url.split('.').pop();
+  return blacklistedFileExtensions.includes(urlExtension);
 };
 
 const document = new JSDOM('').window;

--- a/constants/common.js
+++ b/constants/common.js
@@ -104,9 +104,7 @@ export const sortAlphaAttributes = htmlString => {
 export const isBlacklistedFileExtensions = (url, blacklistedFileExtensions) => {
   const urlExtension = url.split('.').pop(); 
 
-  const isBlacklisted = blacklistedFileExtensions.some(extension =>
-    urlExtension.includes(extension)
-  );
+  const isBlacklisted = blacklistedFileExtensions.includes(urlExtension);
 
   return isBlacklisted;
 };

--- a/constants/common.js
+++ b/constants/common.js
@@ -341,8 +341,6 @@ const checkUrlConnectivityWithBrowser = async (
 
       res.content = await page.content();
     } catch (error) {
-      // not sure what errors are thrown
-      console.log(error);
       silentLogger.error(error);
       res.status = constants.urlCheckStatuses.systemError.code;
     } finally {
@@ -433,6 +431,7 @@ export const prepareData = argv => {
     nameEmail,
     customFlowLabel,
     specifiedMaxConcurrency,
+    needsReviewItems
   } = argv;
 
   return {
@@ -450,6 +449,7 @@ export const prepareData = argv => {
     nameEmail,
     customFlowLabel,
     specifiedMaxConcurrency,
+    needsReviewItems
   };
 };
 
@@ -972,8 +972,6 @@ export const submitFormViaPlaywright = async (
       silentLogger.info('Unable to detect networkidle');
     }
   } catch (error) {
-    // not sure what errors are thrown
-    console.log(error);
     silentLogger.error(error);
   } finally {
     await browserContext.close();

--- a/constants/common.js
+++ b/constants/common.js
@@ -102,8 +102,13 @@ export const sortAlphaAttributes = htmlString => {
 };
 
 export const isBlacklistedFileExtensions = (url, blacklistedFileExtensions) => {
-  const urlExtension = url.split('.').pop();
-  return blacklistedFileExtensions.includes(urlExtension);
+  const urlExtension = url.split('.').pop(); 
+
+  const isBlacklisted = blacklistedFileExtensions.some(extension =>
+    urlExtension.includes(extension)
+  );
+
+  return isBlacklisted;
 };
 
 const document = new JSDOM('').window;
@@ -403,7 +408,6 @@ export const checkUrl = async (
       res.status = constants.urlCheckStatuses.notASitemap.code;
     }
   }
-
   return res;
 };
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -186,8 +186,12 @@ const urlsCrawledObj = {
   toScan: [],
   scanned: [],
   invalid: [],
-  redirects: [],
+  scannedRedirects: [],
+  notScannedRedirects: [],
   outOfDomain: [],
+  blacklisted: [],
+  exceededRequests: [],
+  forbidden: []
 };
 
 const scannerTypes = {

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -186,6 +186,7 @@ const urlsCrawledObj = {
   toScan: [],
   scanned: [],
   invalid: [],
+  redirects: [],
   outOfDomain: [],
 };
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -258,7 +258,7 @@ export const impactOrder = {
 };
 
 export const formDataFields = {
-  formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSeUmqoVRSvMrW1DRi1KNMemWyKvDbEWGJp2dve4qb8QB3Zgvw/formResponse`,
+  formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSem5C8fyNs5TiU5Vv2Y63-SH7CHN86f-LEPxeN_1u_ldUbgUA/formResponse`,
   websiteUrlField: 'entry.1562345227',
   scanTypeField: 'entry.1148680657',
   emailField: 'entry.52161304',

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -110,6 +110,10 @@ const crawlDomain = async (
             pageTitle: results.pageTitle,
             actualUrl: request.loadedUrl, // i.e. actualUrl
           });
+          urlsCrawled.redirects.push({
+            fromUrl: request.url,
+            toUrl: request.loadedUrl, // i.e. actualUrl
+          });
           results.url = request.url;
           results.actualUrl = request.loadedUrl;
         } else {

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -115,9 +115,9 @@ const crawlDomain = async (
         // For deduplication, if the URL is redirected, we want to store the original URL and the redirected URL (actualUrl)
         const isRedirected = !areLinksEqual(request.loadedUrl, request.url);
         if (isRedirected) {
-          const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(item => {
-            (item.actualUrl || item.url) === request.loadedUrl;
-          });
+          const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(
+            item => (item.actualUrl || item.url) === request.loadedUrl,
+          );
 
           if (isLoadedUrlInCrawledUrls) {
             urlsCrawled.notScannedRedirects.push({

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -1,4 +1,4 @@
-import crawlee, { playwrightUtils } from 'crawlee';
+import crawlee from 'crawlee';
 import {
   createCrawleeSubFolders,
   preNavigationHooks,

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -7,11 +7,10 @@ import {
   failedRequestHandler,
 } from './commonCrawlerFunc.js';
 
-import constants, { blackListedFileExtensions } from '../constants/constants.js';
+import constants from '../constants/constants.js';
 import {
   getLinksFromSitemap,
   getPlaywrightLaunchOptions,
-  isBlacklistedFileExtensions,
   messageOptions,
 } from '../constants/common.js';
 import { areLinksEqual, isWhitelistedContentType } from '../utils.js';

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -90,9 +90,9 @@ const crawlSitemap = async (
 
         const isRedirected = !areLinksEqual(request.loadedUrl, request.url);
         if (isRedirected) {
-          const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(item => {
-            (item.actualUrl || item.url) === request.loadedUrl;
-          });
+          const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(
+            item =>  (item.actualUrl || item.url) === request.loadedUrl,
+          );
 
           if (isLoadedUrlInCrawledUrls) {
             urlsCrawled.notScannedRedirects.push({

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -71,6 +71,10 @@ const crawlSitemap = async (
             pageTitle: results.pageTitle,
             actualUrl: request.loadedUrl, // i.e. actualUrl
           });
+          urlsCrawled.redirects.push({
+            fromUrl: request.url,
+            toUrl: request.loadedUrl, // i.e. actualUrl
+          });
           results.url = request.url;
           results.actualUrl = request.loadedUrl;
         } else {

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -86,7 +86,7 @@ const crawlSitemap = async (
       pagesCrawled++;
 
       if (status === 200 && isWhitelistedContentType(contentType)) {
-        const results = await runAxeScript(page);
+        const results = await runAxeScript(needsReview, page);
         if (request.loadedUrl !== request.url) {
           const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(item => {
             (item.actualUrl || item.url) === request.loadedUrl;

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -133,18 +133,6 @@ const writeHTML = async (allIssues, storagePath, scanType, customFlowLabel, html
   }
 };
 
-const writeSummaryHTML = async (allIssues, storagePath, scanType, customFlowLabel, htmlFilename = 'summary') => {
-  const ejsString = fs.readFileSync(path.join(__dirname, './static/ejs/summary.ejs'), 'utf-8');
-  const template = ejs.compile(ejsString, {
-    filename: path.join(__dirname, './static/ejs/summary.ejs'),
-  });
-  const html = template(allIssues);
-  fs.writeFileSync(`${storagePath}/reports/${htmlFilename}.html`, html);
-  if (!process.env.RUNNING_FROM_PH_GUI && scanType === 'Customized' && customFlowLabel) {
-    addCustomFlowLabel(`${storagePath}/reports/${htmlFilename}.html`, customFlowLabel);
-  }
-};
-
 const addCustomFlowLabel = (path, customFlowLabel) => {
     const data = fs.readFileSync(path, {encoding: "utf-8"}); 
     const result = data.replaceAll(/Custom Flow/g, customFlowLabel); 
@@ -394,7 +382,6 @@ export const generateArtifacts = async (randomToken, urlScanned, scanType, viewp
   const fileDestinationPath = `${storagePath}/reports/summary.pdf`;
   await writeResults(allIssues, storagePath);
   await writeHTML(allIssues, storagePath, scanType, customFlowLabel);
-  await writeSummaryHTML(allIssues, storagePath, scanType, customFlowLabel);
   await writeSummaryPdf(htmlFilename, fileDestinationPath);
   return createRuleIdJson(allIssues);
 };

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -133,6 +133,18 @@ const writeHTML = async (allIssues, storagePath, scanType, customFlowLabel, html
   }
 };
 
+const writeSummaryHTML = async (allIssues, storagePath, scanType, customFlowLabel, htmlFilename = 'summary') => {
+  const ejsString = fs.readFileSync(path.join(__dirname, './static/ejs/summary.ejs'), 'utf-8');
+  const template = ejs.compile(ejsString, {
+    filename: path.join(__dirname, './static/ejs/summary.ejs'),
+  });
+  const html = template(allIssues);
+  fs.writeFileSync(`${storagePath}/reports/${htmlFilename}.html`, html);
+  if (!process.env.RUNNING_FROM_PH_GUI && scanType === 'Customized' && customFlowLabel) {
+    addCustomFlowLabel(`${storagePath}/reports/${htmlFilename}.html`, customFlowLabel);
+  }
+};
+
 const addCustomFlowLabel = (path, customFlowLabel) => {
     const data = fs.readFileSync(path, {encoding: "utf-8"}); 
     const result = data.replaceAll(/Custom Flow/g, customFlowLabel); 
@@ -182,15 +194,13 @@ const writeSummaryPdf = async (htmlFilePath, fileDestinationPath) => {
 
   await context.close();
   await browser.close();
+
+  fs.unlinkSync(htmlFilePath)
 };
 
 const pushResults = async (rPath, allIssues) => {
   const pageResults = await parseContentToJson(rPath);
   const { url, pageTitle, actualUrl } = pageResults;
-
-  if (actualUrl) {
-    return;
-  }
 
   allIssues.totalPagesScanned += 1;
 
@@ -382,6 +392,7 @@ export const generateArtifacts = async (randomToken, urlScanned, scanType, viewp
   const fileDestinationPath = `${storagePath}/reports/summary.pdf`;
   await writeResults(allIssues, storagePath);
   await writeHTML(allIssues, storagePath, scanType, customFlowLabel);
+  await writeSummaryHTML(allIssues, storagePath, scanType, customFlowLabel);
   await writeSummaryPdf(htmlFilename, fileDestinationPath);
   return createRuleIdJson(allIssues);
 };

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -198,7 +198,11 @@ const writeSummaryPdf = async (htmlFilePath, fileDestinationPath) => {
 
 const pushResults = async (rPath, allIssues) => {
   const pageResults = await parseContentToJson(rPath);
-  const { url, pageTitle } = pageResults;
+  const { url, pageTitle, actualUrl } = pageResults;
+
+  if (actualUrl) {
+    return;
+  }
 
   allIssues.totalPagesScanned += 1;
 
@@ -222,6 +226,7 @@ const pushResults = async (rPath, allIssues) => {
           helpUrl,
           conformance,
           totalItems: 0,
+          // numberOfPagesAffectedAfterRedirects: 0,
           pagesAffected: {},
         };
       }
@@ -238,9 +243,21 @@ const pushResults = async (rPath, allIssues) => {
 
       if (!(url in currRuleFromAllIssues.pagesAffected)) {
         currRuleFromAllIssues.pagesAffected[url] = { pageTitle, items: [] };
+        /*if (actualUrl) {
+          currRuleFromAllIssues.pagesAffected[url].actualUrl = actualUrl;
+          // Deduct duplication count from totalItems
+          currRuleFromAllIssues.totalItems -= 1;
+          // Previously using pagesAffected.length to display no. of pages affected
+          // However, since pagesAffected array contains duplicates, we need to deduct the duplicates
+          // Hence, start with negative offset, will add pagesAffected.length later
+          currRuleFromAllIssues.numberOfPagesAffectedAfterRedirects -= 1;
+          currCategoryFromAllIssues.totalItems -= 1;
+        }*/
       }
 
       currRuleFromAllIssues.pagesAffected[url].items.push(...items);
+      // currRuleFromAllIssues.numberOfPagesAffectedAfterRedirects +=
+      //   currRuleFromAllIssues.pagesAffected.length;
     });
   });
 };

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -200,7 +200,7 @@ const writeSummaryPdf = async (htmlFilePath, fileDestinationPath) => {
 
 const pushResults = async (rPath, allIssues) => {
   const pageResults = await parseContentToJson(rPath);
-  const { url, pageTitle, actualUrl } = pageResults;
+  const { url, pageTitle } = pageResults;
 
   allIssues.totalPagesScanned += 1;
 

--- a/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/static/ejs/partials/components/pagesScannedModal.ejs
@@ -18,7 +18,6 @@
           <%= scanType === 'Customized' ? totalPagesScanned + ' pages' : ''%>
         </h6>
         <ul class="unbulleted-list">
-          <% pagesScanned.forEach((page, index) => { %> <% if (page.actualUrl) { return; }%>
           <li>
             <a href="<%= page.url %>" target="_blank"><%= page.pageTitle %></a>
             <span><%= page.url %></span>

--- a/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/static/ejs/partials/components/pagesScannedModal.ejs
@@ -18,6 +18,7 @@
           <%= scanType === 'Customized' ? totalPagesScanned + ' pages' : ''%>
         </h6>
         <ul class="unbulleted-list">
+          <% pagesScanned.forEach((page, index) => { %> 
           <li>
             <a href="<%= page.url %>" target="_blank"><%= page.pageTitle %></a>
             <span><%= page.url %></span>

--- a/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/static/ejs/partials/components/pagesScannedModal.ejs
@@ -1,27 +1,31 @@
-<div 
-    id="pagesScannedModal"
-    class="modal fade"
-    aria-labelledby="pagesScannedModalLabel"
-    aria-hidden="true"
-    tabindex="-1"
-    >
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title fw-bold" id="pagesScannedModalLabel"><%= scanType === 'Customized' ? 'Custom Flow' : totalPagesScanned + ' pages'%></h4>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>  
-            </div>
-            <div class="modal-body">
-                <h6 class="modal-title fw-bold"><%= scanType === 'Customized' ? totalPagesScanned + ' pages' : ''%></h6>
-                <ul class="unbulleted-list">
-                    <% pagesScanned.forEach((page, index) => { %>
-                        <li>
-                          <a href="<%= page.url %>" target="_blank"><%= page.pageTitle %></a>
-                          <span><%= page.url %></span>
-                        </li>
-                    <% }) %>
-                </ul>
-            </div>
-        </div>
+<div
+  id="pagesScannedModal"
+  class="modal fade"
+  aria-labelledby="pagesScannedModalLabel"
+  aria-hidden="true"
+  tabindex="-1"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title fw-bold" id="pagesScannedModalLabel">
+          <%= scanType === 'Customized' ? 'Custom Flow' : totalPagesScanned + ' pages'%>
+        </h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <h6 class="modal-title fw-bold">
+          <%= scanType === 'Customized' ? totalPagesScanned + ' pages' : ''%>
+        </h6>
+        <ul class="unbulleted-list">
+          <% pagesScanned.forEach((page, index) => { %> <% if (page.actualUrl) { return; }%>
+          <li>
+            <a href="<%= page.url %>" target="_blank"><%= page.pageTitle %></a>
+            <span><%= page.url %></span>
+          </li>
+          <% }) %>
+        </ul>
+      </div>
     </div>
+  </div>
 </div>

--- a/static/ejs/partials/footer.ejs
+++ b/static/ejs/partials/footer.ejs
@@ -6,7 +6,7 @@
     </div>
     <div class="col-sm-6 text-sm-end">
       Created by
-      <a href="https://form.gov.sg/64d1fcde4d0bb70012010995" target="_blank"
+      <a href="https://go.gov.sg/accessibility" target="_blank"
         >GovTech Accessibility Enabling Team</a
       >
     </div>

--- a/static/ejs/partials/footer.ejs
+++ b/static/ejs/partials/footer.ejs
@@ -6,7 +6,7 @@
     </div>
     <div class="col-sm-6 text-sm-end">
       Created by
-      <a href="https://go.gov.sg/accessibility" target="_blank"
+      <a href="https://form.gov.sg/64d1fcde4d0bb70012010995" target="_blank"
         >GovTech Accessibility Enabling Team</a
       >
     </div>

--- a/static/ejs/partials/footer.ejs
+++ b/static/ejs/partials/footer.ejs
@@ -1,7 +1,7 @@
 <footer aria-label="Report footer" id="footer" class="card">
   <div class="row mx-0">
     <div class="col-sm-6 text-sm-start">
-      <a href="mailto:enquiries_HATS@tech.gov.sg">Help us improve</a>
+      <a href="https://form.gov.sg/64d1fcde4d0bb70012010995">Help us improve</a>
       <hr class="d-sm-none" />
     </div>
     <div class="col-sm-6 text-sm-end">

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -129,6 +129,24 @@ category summary is clicked %>
     document.getElementById('expandedRuleCategorySelectors').replaceChildren(...categorySelectors);
   }
 
+  const ruleIdsWithHtml = [
+  'aria-allowed-attr',
+  'aria-hidden-focus',
+  'aria-input-field-name',
+  'aria-required-attr',
+  'aria-required-children',
+  'aria-required-parent',
+  'aria-roles',
+  'aria-toggle-field-name',
+  'aria-valid-attr-value',
+  'aria-valid-attr',
+  'input-button-name',
+  'link-name',
+  'nested-interactive',
+  'avoid-inline-spacing',
+  'aria-allowed-role',
+  ];
+
   function buildExpandedRuleCategoryContent(category, ruleInCategory) {
     const contentContainer = document.getElementById('expandedRuleCategoryContent');
 

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -259,7 +259,7 @@ category summary is clicked %>
                     item.html,
                   )}</code></pre>ƒƒ
                 </div>
-                <hr />å
+                <hr />
                 <div class="d-flex justify-content-between">
                 <div class="fw-bold">${item.displayNeedsReview ? 'Details' : 'How to fix'}</div>
                 <div class="page-item-card-section-content">

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -273,6 +273,10 @@ category summary is clicked %>
   }
 
   function generateItemMessageElement(rawMessage) {
+    if (rawMessage.includes('\n\nFix')) {
+      rawMessage = rawMessage.replace('\n\nFix', '\n  Fix');
+    }
+
     const htmlEscapedMessageArray = rawMessage.split('\n  ').map(m => htmlEscapeString(m));
 
       let i = 0;

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -144,8 +144,43 @@ category summary is clicked %>
 
     const accordionsList = createElementFromString(`<ul class="unbulleted-list"></ul>`);
 
+    // const duplicatedLinks = {};
+
     ruleInCategory.pagesAffected.forEach((page, index) => {
       const accordionId = `${ruleInCategory.rule}-${category}-page-${index}`;
+      /*const accordionId = `${ruleInCategory.rule}-${category}-${page.url}`;
+      if (page.hasOwnProperty('actualUrl')) {
+        const existingAccordionId = `${ruleInCategory.rule}-${category}-${page.actualUrl}`;
+        // Check if the page already has an accordion for the actual URL this page is a duplicate of
+        const existingList = Array.from(accordionsList.children);
+        const existingEle = existingList.find(
+          ele => ele.children[0].children[0].children[0].id === `${existingAccordionId}-title`,
+        );
+        if (existingEle) {
+          // If the page already has an accordion for the actual URL this page is a duplicate of
+          if (
+            !duplicatedLinks.hasOwnProperty(page.actualUrl) &&
+            !page.actualUrl.hasOwnProperty('redirectUrls')
+          ) {
+            duplicatedLinks[page.actualUrl] = {};
+            duplicatedLinks[page.actualUrl]['redirectUrls'] = [page.url];
+          } else {
+            duplicatedLinks[page.actualUrl]['redirectUrls'].push(page.url);
+          }
+          duplicatedLinks[page.actualUrl]['elementId'] = `${existingAccordionId}-content`;
+          // const htmlSnippet = `<br><a aria-label="URL to ${page.pageTitle}" href="${page.url}" target="_blank">
+          //  ${page.url}
+          //</a>`;
+          //existingEle.children[0].children[0].children[1].children[0].children[0].insertAdjacentHTML(
+          //  'afterend',
+          //  htmlSnippet,
+          // ); 
+
+          // Terminate the current iteration early to prevent creation of a new accordion
+          return;
+        }
+      }*/
+
       const accordion = createElementFromString(`
         <li>
           <div class="accordion mt-2 ${category}">
@@ -218,6 +253,22 @@ category summary is clicked %>
       return accordion;
     });
     contentContainer.replaceChildren(contentTitle, accordionsList);
+
+    // Insert duplicated links into existing accordions
+    /*Object.keys(duplicatedLinks).forEach(baseUrl => {
+      const existingAccordionBody = document.getElementById(duplicatedLinks[baseUrl]['elementId']);
+      const paragraphSnippet = `<br><p>Here are the list of URLs that also redirects to the above</p>`;
+      existingAccordionBody.children[0].children[0].insertAdjacentHTML(
+        'afterend',
+        paragraphSnippet,
+      );
+      duplicatedLinks[baseUrl]['redirectUrls'].forEach(redirectUrl => {
+        const htmlSnippet = `<br><a aria-label="URL to ${baseUrl}" href="${redirectUrl}" target="_blank">
+          ${redirectUrl}
+        </a>`;
+        existingAccordionBody.children[0].children[1].insertAdjacentHTML('afterend', htmlSnippet);
+      });
+    });*/
     hljs.highlightAll();
   }
 

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -130,21 +130,21 @@ category summary is clicked %>
   }
 
   const ruleIdsWithHtml = [
-  'aria-allowed-attr',
-  'aria-hidden-focus',
-  'aria-input-field-name',
-  'aria-required-attr',
-  'aria-required-children',
-  'aria-required-parent',
-  'aria-roles',
-  'aria-toggle-field-name',
-  'aria-valid-attr-value',
-  'aria-valid-attr',
-  'input-button-name',
-  'link-name',
-  'nested-interactive',
-  'avoid-inline-spacing',
-  'aria-allowed-role',
+    'aria-allowed-attr',
+    'aria-hidden-focus',
+    'aria-input-field-name',
+    'aria-required-attr',
+    'aria-required-children',
+    'aria-required-parent',
+    'aria-roles',
+    'aria-toggle-field-name',
+    'aria-valid-attr-value',
+    'aria-valid-attr',
+    'input-button-name',
+    'link-name',
+    'nested-interactive',
+    'avoid-inline-spacing',
+    'aria-allowed-role',
   ];
 
   function buildExpandedRuleCategoryContent(category, ruleInCategory) {
@@ -240,31 +240,34 @@ category summary is clicked %>
       const elementCardsList = createElementFromString('<ul class="unbulleted-list"></ul>');
 
       page.items.forEach(item => {
-        if (!item.needsReview){
-          const itemCard = createElementFromString(`
-            <li>
-              <div class="card mt-3">
-                <div class="p-3">
-                  <div class="d-flex justify-content-between">
-                    <div class="fw-bold">HTML element</div>
-                    <pre class="page-item-card-section-content"><code class="language-html">${htmlEscapeString(
-                      item.html,
-                    )}</code></pre>
-                  </div>
-                  <hr />
-                  <div class="d-flex justify-content-between">
-                    <div class="fw-bold">How to fix</div>
-                    <div class="page-item-card-section-content">
-                      ${generateItemMessageElement(item.message)}
-                    </div>
-                  </div>
-                </div>
+        const itemCard = createElementFromString(`
+          <li>
+            <div class="card mt-3">
+              ${
+                item.displayNeedsReview
+                  ? `
+              <div class="needsReview">
+                This occurrence might be a false positive that needs to be verified by a human.
               </div>
-            <li>
-          `);
-  
-          elementCardsList.appendChild(itemCard);
-        }
+              `
+                  : ``
+              }
+              <div class="p-3">
+                <div class="d-flex justify-content-between">
+                  <div class="fw-bold">HTML element</div>
+                  <pre class="page-item-card-section-content"><code class="language-html">${htmlEscapeString(
+                    item.html,
+                  )}</code></pre>ƒƒ
+                </div>
+                <hr />å
+                <div class="d-flex justify-content-between">
+                <div class="fw-bold">${item.displayNeedsReview ? 'Details' : 'How to fix'}</div>
+                <div class="page-item-card-section-content">
+                  ${generateItemMessageElement(item.displayNeedsReview, item.message)}
+                </div>
+          </li>`);
+
+        elementCardsList.appendChild(itemCard);
       });
 
       accordionBody.appendChild(elementCardsList);
@@ -290,16 +293,22 @@ category summary is clicked %>
     hljs.highlightAll();
   }
 
-  function generateItemMessageElement(rawMessage) {
+  function generateItemMessageElement(displayNeedsReview, rawMessage) {
     if (rawMessage.includes('\n\nFix')) {
       rawMessage = rawMessage.replace('\n\nFix', '\n  Fix');
     }
 
     const htmlEscapedMessageArray = rawMessage.split('\n  ').map(m => htmlEscapeString(m));
 
+    if (displayNeedsReview) {
+      if (htmlEscapedMessageArray.length === 1) {
+        return `<p class="mb-0">${htmlEscapedMessageArray[0]}</p>`;
+      } else {
+        return `<ul>${htmlEscapedMessageArray.map(m => `<li>${m}</li>`).join('')}</ul>`;
+      }
+    } else {
       let i = 0;
       const elements = [];
-
       while (i < htmlEscapedMessageArray.length) {
         if (htmlEscapedMessageArray[i].startsWith('Fix ')) {
           elements.push(`<p class="mb-0">${htmlEscapedMessageArray[i]}</p>`);
@@ -316,10 +325,10 @@ category summary is clicked %>
           elements.push(`<ul>${fixesList.join('')}</ul>`);
         }
       }
-
+  
       return elements.join('');
     }
-  
+  }
 
   const whyItMatters = {
     accesskeys:

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -325,7 +325,7 @@ category summary is clicked %>
           elements.push(`<ul>${fixesList.join('')}</ul>`);
         }
       }
-  
+
       return elements.join('');
     }
   }

--- a/utils.js
+++ b/utils.js
@@ -34,7 +34,7 @@ export const isWhitelistedContentType = contentType => {
 
 export const getStoragePath = randomToken =>
   `results/${randomToken}_${
-    constants.urlsCrawledObj.scanned.length - constants.urlsCrawledObj.redirects.length
+    constants.urlsCrawledObj.scanned.length
   }pages`;
 
 export const createDetailsAndLogs = async (scanDetails, randomToken) => {

--- a/utils.js
+++ b/utils.js
@@ -191,3 +191,22 @@ export const zipResults = (zipName, resultsPath) => {
     }
   }
 };
+
+// areLinksEqual compares 2 string URLs and ignores comparison of 'www.' and url protocol
+// i.e. 'http://google.com' and 'https://www.google.com' returns true
+export const areLinksEqual = (link1, link2) => {
+  try {
+    const format = link => {
+      return new URL(link.replace(/www\./, ''));
+    };
+    const l1 = format(link1);
+    const l2 = format(link2);
+
+    const areHostEqual = l1.host === l2.host;
+    const arePathEqual = l1.pathname === l2.pathname;
+
+    return areHostEqual && arePathEqual;
+  } catch (error) {
+    return l1 === l2;
+  }
+};

--- a/utils.js
+++ b/utils.js
@@ -33,7 +33,9 @@ export const isWhitelistedContentType = contentType => {
 };
 
 export const getStoragePath = randomToken =>
-  `results/${randomToken}_${constants.urlsCrawledObj.scanned.length}pages`;
+  `results/${randomToken}_${
+    constants.urlsCrawledObj.scanned.length - constants.urlsCrawledObj.redirects.length
+  }pages`;
 
 export const createDetailsAndLogs = async (scanDetails, randomToken) => {
   const storagePath = getStoragePath(randomToken);


### PR DESCRIPTION
This PR adds... 

- "-f" flag in node cli to provide user the choice of including rule items requiring manual review in the generated report
-  Stop Crawlee from performing repeated scans due to redirects 
- Removal of summary.html from reports directory
- Changing Crawlee's default error logging behaviour to only log errors in console during scans
- Separating all URLs crawled into new arrays for future display to provide more information to users (blacklisted, forbidden, invalid, scannedRedirects ...)
- Implementing functionality to traverse through nested sitemap.xml  / txt to reach destination webpages for sitemap scans

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (n.a.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions (n.a)
