### PR TITLE
Change filename used for scan results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ nodejs-*
 ms-playwright/
 a11y-scan-results*.zip
 PHScan_*/
+
+# match YYYYMMDD_HHMMSS_* pattern for dataset files
+[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]_*/

--- a/cli.js
+++ b/cli.js
@@ -323,10 +323,6 @@ const scanInit = async argvs => {
       break;
   }
 
-  const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
-
-  const domain = argvs.isLocalSitemap ? 'custom' : new URL(argvs.url).hostname;
-
   const data = prepareData(argvs);
 
   setHeadlessMode(data.isHeadless);
@@ -342,11 +338,6 @@ const scanInit = async argvs => {
   } else {
     screenToScan = 'Desktop';
   }
-
-  data.randomToken = `PHScan_${domain}_${date}_${time}_${argvs.scanner.replaceAll(
-    ' ',
-    '_',
-  )}_${screenToScan.replaceAll(' ', '_')}`;
 
   /**
    * Cloning a second time with random token for parallel browser sessions

--- a/constants/common.js
+++ b/constants/common.js
@@ -429,6 +429,14 @@ export const prepareData = argv => {
     needsReviewItems
   } = argv;
 
+  // construct filename for scan results
+  const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
+  const domain = argv.isLocalSitemap ? 'custom' : new URL(argv.url).hostname;
+  const sanitisedLabel = customFlowLabel
+    ? `_${customFlowLabel.replaceAll(' ', '_')}`
+    : '';
+  const resultFilename = `${date}_${time}${sanitisedLabel}_${domain}`;
+
   return {
     type: scanner,
     url: isLocalSitemap ? url : finalUrl,
@@ -444,7 +452,8 @@ export const prepareData = argv => {
     nameEmail,
     customFlowLabel,
     specifiedMaxConcurrency,
-    needsReviewItems
+    needsReviewItems,
+    randomToken: resultFilename,
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -73,15 +73,6 @@ if (userData) {
 
     setHeadlessMode(data.isHeadless);
 
-    const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
-
-    const domain = answers.isLocalSitemap ? 'custom' : new URL(answers.url).hostname;
-
-    data.randomToken = `PHScan_${domain}_${date}_${time}_${answers.scanner.replaceAll(
-      ' ',
-      '_',
-    )}_${screenToScan.replaceAll(' ', '_')}`;
-
     printMessage(['Scanning website...'], messageOptions);
 
     if (answers.scanner === constants.scannerTypes.custom) {
@@ -156,15 +147,6 @@ if (userData) {
     const data = prepareData(answers);
 
     setHeadlessMode(data.isHeadless);
-
-    const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
-
-    const domain = answers.isLocalSitemap ? 'custom' : new URL(answers.url).hostname;
-
-    data.randomToken = `PHScan_${domain}_${date}_${time}_${answers.scanner.replaceAll(
-      ' ',
-      '_',
-    )}_${screenToScan.replaceAll(' ', '_')}`;
 
     printMessage(['Scanning website...'], messageOptions);
 

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -19,8 +19,10 @@ export const init = async (entryUrl, customFlowLabelTestString, name, email) => 
 
   const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
   const domain = new URL(entryUrl).hostname;
-
-  const randomToken = `PHScan_${domain}_${date}_${time}_IntegratedScan`;
+  const sanitisedLabel = customFlowLabelTestString
+    ? `_${customFlowLabelTestString.replaceAll(' ', '_')}`
+    : '';
+  const randomToken = `${date}_${time}${sanitisedLabel}_${domain}`;
 
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 

--- a/utils.js
+++ b/utils.js
@@ -33,9 +33,7 @@ export const isWhitelistedContentType = contentType => {
 };
 
 export const getStoragePath = randomToken =>
-  `results/${randomToken}_${
-    constants.urlsCrawledObj.scanned.length
-  }pages`;
+`results/${randomToken}`;
 
 export const createDetailsAndLogs = async (scanDetails, randomToken) => {
   const storagePath = getStoragePath(randomToken);


### PR DESCRIPTION
This PR adds... 
- Change filename of scan results to be less verbose according to the specification

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
