### PR TITLE
Fix customFlowLabel to not use string value

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -134,11 +134,7 @@ const writeHTML = async (
   const html = template(allIssues);
   fs.writeFileSync(`${storagePath}/reports/${htmlFilename}.html`, html);
 
-  if (
-    !process.env.RUNNING_FROM_PH_GUI &&
-    scanType === 'Customized' &&
-    customFlowLabel !== 'undefined'
-  ) {
+  if (!process.env.RUNNING_FROM_PH_GUI && scanType === 'Customized' && customFlowLabel) {
     addCustomFlowLabel(`${storagePath}/reports/${htmlFilename}.html`, customFlowLabel);
   }
 };

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -53,7 +53,15 @@ const playwrightAxeGenerator = async data => {
     }
   }
 
-  let { isHeadless, randomToken, deviceChosen, customDevice, viewportWidth, customFlowLabel, needsReviewItems } = data;
+  let {
+    isHeadless,
+    randomToken,
+    deviceChosen,
+    customDevice,
+    viewportWidth,
+    customFlowLabel,
+    needsReviewItems,
+  } = data;
   // these will be appended to the generated script if the scan is run from CLI/index.
   // this is so as the final generated script can be rerun after the scan.
   const importStatements = `
@@ -352,7 +360,7 @@ const clickFunc = async (elem,page) => {
       : 'Desktop'
   }', 
   urlsCrawled.scanned, 
-  '${customFlowLabel}');
+  ${customFlowLabel});
 
   await submitFormViaPlaywright(
     "${data.browser}",


### PR DESCRIPTION
This PR adds

* Fix customFlowLabel to not use string value

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
