### PR TITLE
Improve management of intermediate folders for custom scans

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -77,7 +77,7 @@ export const blackListedFileExtensions = [
   'webp',
 ];
 
-export const intermediateScreenshotsPath = './screenshots';
+export const getIntermediateScreenshotsPath = datasetsPath => `${datasetsPath}/screenshots`;
 export const destinationPath = storagePath => `${storagePath}/screenshots`;
 
 /**  Get the path to Default Profile in the Chrome Data Directory

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -19,7 +19,7 @@ import {
   createScreenshotsFolder,
 } from '#root/utils.js';
 import constants, {
-  intermediateScreenshotsPath,
+  getIntermediateScreenshotsPath,
   getExecutablePath,
   removeQuarantineFlag,
 } from '#root/constants/constants.js';
@@ -61,8 +61,11 @@ const playwrightAxeGenerator = async data => {
     import { getComparator } from 'playwright-core/lib/utils';
     import { createCrawleeSubFolders, runAxeScript } from '#root/crawlers/commonCrawlerFunc.js';
     import { generateArtifacts } from '#root/mergeAxeResults.js';
-    import { createAndUpdateResultsFolders, createDetailsAndLogs, createScreenshotsFolder } from '#root/utils.js';
-    import constants, { intermediateScreenshotsPath, getExecutablePath, removeQuarantineFlag } from '#root/constants/constants.js';
+    import { createAndUpdateResultsFolders, createDetailsAndLogs, createScreenshotsFolder, cleanUp } from '#root/utils.js';
+    import constants, {
+        getIntermediateScreenshotsPath,
+        getExecutablePath, removeQuarantineFlag
+    } from '#root/constants/constants.js';
     import fs from 'fs';
     import path from 'path';
     import { isSkippedUrl, submitFormViaPlaywright } from '#root/constants/common.js';
@@ -72,6 +75,9 @@ const playwrightAxeGenerator = async data => {
 
   `;
   const block1 = `const blacklistedPatternsFilename = 'exclusions.txt';
+
+// checks and delete datasets path if it already exists
+await cleanUp('${randomToken}');
 
 process.env.CRAWLEE_STORAGE_DIR = '${randomToken}';
 
@@ -111,8 +117,10 @@ var index = 1;
 var urlImageDictionary = {};
 let pageUrl;
 
+const intermediateScreenshotsPath = getIntermediateScreenshotsPath('${randomToken}');
+
 const checkIfScanRequired = async page => {
-  const imgPath = './screenshots/PHScan-screenshot' + index.toString() + '.png';
+  const imgPath = intermediateScreenshotsPath + '/PHScan-screenshot' + index.toString() + '.png';
 
 index += 1;
 
@@ -321,20 +329,6 @@ const clickFunc = async (elem,page) => {
 
   const block2 = `  return urlsCrawled;
         })().then(async (urlsCrawled) => {
-            fs.readdir(intermediateScreenshotsPath, (err, files) => {
-                if (err) {
-                  console.error(\`Error reading directory: \${err}\`);
-                  return;
-                }
-                const filteredFiles = files.filter(file => file.includes('canny'));
-            
-                filteredFiles.forEach(file => {
-                  fs.unlink(\`./screenshots/\${file}\`,  err => {
-                    if (err) throw err;
-                  });
-                });
-              });
-
             scanDetails.endTime = new Date().getTime();
             scanDetails.urlsCrawled = urlsCrawled;
             await createDetailsAndLogs(scanDetails, '${randomToken}');

--- a/utils.js
+++ b/utils.js
@@ -2,7 +2,7 @@ import { execFileSync, execSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
-import { intermediateScreenshotsPath, destinationPath } from './constants/constants.js';
+import { destinationPath, getIntermediateScreenshotsPath } from './constants/constants.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -103,6 +103,7 @@ export const createAndUpdateResultsFolders = async randomToken => {
 
 export const createScreenshotsFolder = randomToken => {
   const storagePath = getStoragePath(randomToken);
+  const intermediateScreenshotsPath = getIntermediateScreenshotsPath(randomToken);
   if (fs.existsSync(intermediateScreenshotsPath)) {
     fs.readdir(intermediateScreenshotsPath, (err, files) => {
       if (err) {


### PR DESCRIPTION
This PR adds...
- Move intermediate screenshots folder
- Delete any existing data folders before starting custom scan playbacks to prevent repeated data

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
