### PR TITLE
Fix string parse issue in getByRole calls with 2 options

### DIFF
--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -591,17 +591,19 @@ const clickFunc = async (elem,page) => {
       }
 
       if (line.trim().includes('.getByRole(') && line.trim().includes('.click()') ) {
-        // add includeHidden: true to locator options
+        // add includeHidden: true to getByRole options
         const paramsStartIdx = line.indexOf('getByRole(') + 'getByRole('.length; 
         const paramsEndIdx = line.indexOf(')', paramsStartIdx);
         const paramsStr = line.substring(paramsStartIdx, paramsEndIdx);
-        const params = paramsStr.split("',");
-        const firstParam = params[0] + "'";
-        let newOptions = params[1];
-        if (newOptions) {
-          newOptions = newOptions.trim().replace('}', ', includeHidden: true }');
+        
+        let [firstParam, ...options] = paramsStr.split("',");
+        firstParam = firstParam + "'"; 
+        options = options.join("',");
+
+        if (options) { // falsy if there are no options
+          options = options.trim().replace('}', ', includeHidden: true }');
         }
-        line = line.replace(`getByRole(${paramsStr})`, `getByRole(${firstParam}, ${newOptions})`);
+        line = line.replace(`getByRole(${paramsStr})`, `getByRole(${firstParam}, ${options})`);
       }
 
       if (line.trim().includes('.fill(')) {


### PR DESCRIPTION
This PR adds... 
- Modify string manipulation logic to better handle the getByRole option parameter

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
