### PR TITLE
Added number of pages scanned field in google form scan results

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -27,10 +27,10 @@ const combineRun = async (details, deviceToScan) => {
     userDataDirectory,
     strategy,
     specifiedMaxConcurrency,
-    needsReviewItems
+    needsReviewItems,
   } = envDetails;
 
-  process.env.CRAWLEE_LOG_LEVEL = "ERROR"
+  process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
   const host = type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
@@ -66,7 +66,7 @@ const combineRun = async (details, deviceToScan) => {
         browser,
         userDataDirectory,
         specifiedMaxConcurrency,
-        needsReviewItems
+        needsReviewItems,
       );
       break;
 
@@ -81,7 +81,7 @@ const combineRun = async (details, deviceToScan) => {
         userDataDirectory,
         strategy,
         specifiedMaxConcurrency,
-        needsReviewItems
+        needsReviewItems,
       );
       break;
 
@@ -111,6 +111,7 @@ const combineRun = async (details, deviceToScan) => {
       email,
       name,
       JSON.stringify(basicFormHTMLSnippet),
+      urlsCrawled.scanned.length,
     );
   } else {
     printMessage([`No pages were scanned.`], constants.alertMessageOptions);

--- a/constants/common.js
+++ b/constants/common.js
@@ -930,6 +930,7 @@ export const submitFormViaPlaywright = async (
   email,
   name,
   scanResultsJson,
+  numberOfPagesScanned,
 ) => {
   const dirName = `clone-${Date.now()}`;
   let clonedDir = null;
@@ -945,7 +946,8 @@ export const submitFormViaPlaywright = async (
     `${formDataFields.scanTypeField}=${scanType}&` +
     `${formDataFields.emailField}=${email}&` +
     `${formDataFields.nameField}=${name}&` +
-    `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}`;
+    `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
+    `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}`;
 
   const browserContext = await chromium.launchPersistentContext(clonedDir || userDataDirectory, {
     ...getPlaywrightLaunchOptions(browserToRun),

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -192,7 +192,7 @@ const urlsCrawledObj = {
   outOfDomain: [],
   blacklisted: [],
   exceededRequests: [],
-  forbidden: []
+  forbidden: [],
 };
 
 const scannerTypes = {
@@ -265,6 +265,7 @@ export const formDataFields = {
   emailField: 'entry.52161304',
   nameField: 'entry.1787318910',
   resultsField: 'entry.904051439',
+  numberOfPagesScannedField: 'entry.238043773',
 };
 
 const urlCheckStatuses = {

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -104,6 +104,7 @@ export const init = async (entryUrl, customFlowLabelTestString, name, email) => 
         email,
         name,
         JSON.stringify(basicFormHTMLSnippet),
+        urlsCrawled.scanned.length,
       )
 
     }

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -371,6 +371,7 @@ const clickFunc = async (elem,page) => {
     "${data.nameEmail.split(':')[1]}", 
     "${data.nameEmail.split(':')[0]}",
     JSON.stringify(basicFormHTMLSnippet),
+    urlsCrawled.scanned.length,
   );
         });
         `;


### PR DESCRIPTION
This PR adds

* added new field for google form scan results: number of pages scanned

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
