### PR TITLE
Remove extra symbols in report and add "scanned" to pagesScannedModal

### DIFF
--- a/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/static/ejs/partials/components/pagesScannedModal.ejs
@@ -9,13 +9,13 @@
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title fw-bold" id="pagesScannedModalLabel">
-          <%= scanType === 'Customized' ? 'Custom Flow' : totalPagesScanned + ' pages'%>
+          <%= scanType === 'Customized' ? 'Custom Flow' : totalPagesScanned + ' pages scanned'%>
         </h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <h6 class="modal-title fw-bold">
-          <%= scanType === 'Customized' ? totalPagesScanned + ' pages' : ''%>
+          <%= scanType === 'Customized' ? totalPagesScanned + ' pages scanned' : ''%>
         </h6>
         <ul class="unbulleted-list">
           <% pagesScanned.forEach((page, index) => { %> 

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -257,7 +257,7 @@ category summary is clicked %>
                   <div class="fw-bold">HTML element</div>
                   <pre class="page-item-card-section-content"><code class="language-html">${htmlEscapeString(
                     item.html,
-                  )}</code></pre>ƒƒ
+                  )}</code></pre>
                 </div>
                 <hr />
                 <div class="d-flex justify-content-between">


### PR DESCRIPTION
This PR 
- removes extra symbols in report and add "scanned" to pagesScannedModal

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
