### PR TITLE
Create -x flag for user to include txt file path with domains to exclude

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,6 @@ import _yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import printMessage from 'print-message';
 import { devices } from 'playwright';
-import os from 'os';
 import { cleanUp, zipResults, setHeadlessMode, getVersion, getStoragePath } from './utils.js';
 import {
   checkUrl,
@@ -23,8 +22,8 @@ import {
   validateDirPath,
   validateFilePath,
 } from './constants/common.js';
-import { cliOptions, messageOptions } from './constants/cliFunctions.js';
 import constants from './constants/constants.js';
+import { cliOptions, messageOptions } from './constants/cliFunctions.js';
 import combineRun from './combine.js';
 import playwrightAxeGenerator from './playwrightAxeGenerator.js';
 import { silentLogger } from './logs.js';

--- a/combine.js
+++ b/combine.js
@@ -37,8 +37,18 @@ const combineRun = async (details, deviceToScan) => {
   const host = type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
 
   let blacklistedPatterns = null;
-  if (blacklistedPatternsFilename) {
-    const rawPatterns = fs.readFileSync(blacklistedPatternsFilename).toString();
+  let exclusionsFile = null;
+
+  if (fs.existsSync('exclusions.txt')){
+    exclusionsFile = 'exclusions.txt'
+  } else if (blacklistedPatternsFilename){
+    exclusionsFile = blacklistedPatternsFilename
+  }
+
+  console.log("combine.js exclusionsFile: ", exclusionsFile)
+
+  if (exclusionsFile) {
+    const rawPatterns = fs.readFileSync(exclusionsFile).toString();
     blacklistedPatterns = rawPatterns.split('\n').filter(pattern => pattern.trim() !== '');
 
     let unsafe = blacklistedPatterns.filter(function (pattern) {
@@ -47,7 +57,7 @@ const combineRun = async (details, deviceToScan) => {
 
     if (unsafe.length > 0) {
       let unsafeExpressionsError =
-        'Unsafe expressions detected: ' + unsafe + ' Please revise ' + blacklistedPatternsFilename;
+        'Unsafe expressions detected: ' + unsafe + ' Please revise ' + exclusionsFile;
       consoleLogger.error(unsafeExpressionsError);
       silentLogger.error(unsafeExpressionsError);
       process.exit(1);

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -108,6 +108,12 @@ export const cliOptions = {
     choices: ['true', 'false'],
     demandOption: false,
   },
+  x: {
+    alias: 'blacklistedPatternsFilename',
+    describe: 'Txt file that has a list of pattern of domains to exclude from accessibility scan',
+    type: 'string',
+    demandOption: false,
+  }
 };
 
 export const configureReportSetting = isEnabled => {

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -79,7 +79,7 @@ export const cliOptions = {
     describe: 'Preferred directory to store scan results. Path is relative to your home directory.',
     type: 'string',
     requiresArg: true,
-    demandOption: false
+    demandOption: false,
   },
   j: {
     alias: 'customFlowLabel',
@@ -110,10 +110,11 @@ export const cliOptions = {
   },
   x: {
     alias: 'blacklistedPatternsFilename',
-    describe: 'Txt file that has a list of pattern of domains to exclude from accessibility scan',
+    describe:
+      'Txt file that has a list of pattern of domains to exclude from accessibility scan separated by new line',
     type: 'string',
     demandOption: false,
-  }
+  },
 };
 
 export const configureReportSetting = isEnabled => {

--- a/constants/common.js
+++ b/constants/common.js
@@ -35,18 +35,45 @@ export const dropAllExceptWhitelisted = htmlSnippet => {
   return htmlSnippet.replace(regex, ``);
 };
 
-export const checkForValidPath = dirPath => {
-  if (typeof dirPath === 'string') {
-    const absolutePath = path.isAbsolute(dirPath) ? dirPath : path.resolve(process.cwd(), dirPath);
+// validateDirPath validates a provided directory path
+// returns null if no error
+export const validateDirPath = dirPath => {
+  if (typeof dirPath !== 'string') {
+    return 'Please provide string value of directory path.';
+  }
 
-    try {
-      fs.accessSync(absolutePath);
-      return true;
-    } catch (error) {
-      return false;
+  try {
+    fs.accessSync(dirPath);
+    if (!fs.statSync(dirPath).isDirectory()) {
+      return 'Please provide a directory path.';
     }
-  } else {
-    return false;
+
+    return null;
+  } catch (error) {
+    return 'Please ensure path provided exists.';
+  }
+};
+
+// validateFilePath validates a provided file path
+// returns null if no error
+export const validateFilePath = filePath => {
+  if (typeof filePath !== 'string') {
+    return 'Please provide string value of file path.';
+  }
+
+  try {
+    fs.accessSync(filePath);
+    if (!fs.statSync(filePath).isFile()) {
+      return 'Please provide a file path.';
+    }
+
+    if (path.extname(filePath) !== '.txt') {
+      return 'Please provide a file with txt extension.';
+    }
+
+    return null;
+  } catch (error) {
+    return 'Please ensure path provided exists.';
   }
 };
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -203,6 +203,13 @@ const scannerTypes = {
   custom: 'Custom',
 };
 
+export const guiInfoStatusTypes = {
+  SCANNED: 'scanned',
+  SKIPPED: 'skipped',
+  COMPLETED: 'completed',
+  ERROR: 'error',
+};
+
 let launchOptionsArgs = [];
 
 // Check if running in docker container

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -194,6 +194,7 @@ const urlsCrawledObj = {
   blacklisted: [],
   exceededRequests: [],
   forbidden: [],
+  userExcluded: [],
 };
 
 const scannerTypes = {
@@ -288,8 +289,12 @@ const urlCheckStatuses = {
   },
   notASitemap: { code: 15, message: 'Provided URL or filepath is not a sitemap.' },
   unauthorised: { code: 16, message: 'Provided URL needs basic authorisation.' },
-  browserError: { code: 17, message: "No browser available to run scans. Please ensure you have Chrome or Edge (for Windows only) installed."},
-  axiosTimeout: { code: 18, message: 'Axios timeout exceeded. Falling back on browser checks.'}
+  browserError: {
+    code: 17,
+    message:
+      'No browser available to run scans. Please ensure you have Chrome or Edge (for Windows only) installed.',
+  },
+  axiosTimeout: { code: 18, message: 'Axios timeout exceeded. Falling back on browser checks.' },
 };
 
 const browserTypes = {
@@ -310,7 +315,7 @@ const xmlSitemapTypes = {
 export default {
   allIssueFileName: 'all_issues',
   cliZipFileName: 'a11y-scan-results.zip',
-  exportDirectory: `${process.cwd()}`, 
+  exportDirectory: `${process.cwd()}`,
   maxRequestsPerCrawl,
   maxConcurrency: 25,
   scannerTypes,
@@ -320,7 +325,7 @@ export default {
   launchOptionsArgs: launchOptionsArgs,
   xmlSitemapTypes,
   urlCheckStatuses,
-  launcher: chromium
+  launcher: chromium,
 };
 
 export const rootPath = __dirname;

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -28,8 +28,7 @@ const crawlSitemap = async (
   needsReviewItems,
   blacklistedPatterns,
 ) => {
-  let needsReview = needsReviewItems;
-
+  const needsReview = needsReviewItems;
   const urlsCrawled = { ...constants.urlsCrawledObj };
   const { playwrightDeviceDetailsObject } = viewportSettings;
   const { maxConcurrency } = constants;
@@ -99,7 +98,7 @@ const crawlSitemap = async (
         return;
       }
 
-      pagesCrawled++;
+      pagesCrawled += 1;
 
       if (status === 200 && isWhitelistedContentType(contentType)) {
         const results = await runAxeScript(needsReview, page);

--- a/logs.js
+++ b/logs.js
@@ -1,5 +1,8 @@
+/* eslint-disable no-console */
 /* eslint-disable no-shadow */
 import { createLogger, format, transports } from 'winston';
+import { guiInfoStatusTypes } from './constants/constants.js';
+
 const { combine, timestamp, printf } = format;
 
 // Sample output
@@ -32,8 +35,27 @@ const silentLogger = createLogger({
   ],
 });
 
-export {
-  logFormat,
-  consoleLogger,
-  silentLogger,
+// guiInfoLogger feeds the gui information via console log and is mainly used for scanning process
+export const guiInfoLog = (status, data) => {
+  if (process.env.RUNNING_FROM_PH_GUI) {
+    switch (status) {
+      case guiInfoStatusTypes.COMPLETED:
+        console.log('Electron scan completed');
+        break;
+      case guiInfoStatusTypes.SCANNED:
+      case guiInfoStatusTypes.SKIPPED:
+      case guiInfoStatusTypes.ERROR:
+        console.log(
+          `Electron crawling::${data.numScanned || 0}::${status}::${
+            data.urlScanned || 'no url provided'
+          }`,
+        );
+        break;
+      default:
+        console.log(`Status provided to gui info log not recognized: ${status}`);
+        break;
+    }
+  }
 };
+
+export { logFormat, consoleLogger, silentLogger };

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -5,9 +5,9 @@ import path from 'path';
 import readline from 'readline';
 import safe from 'safe-regex';
 import { devices } from 'playwright';
-import { consoleLogger, silentLogger } from './logs.js';
+import { consoleLogger, silentLogger, guiInfoLog } from './logs.js';
 import { fileURLToPath } from 'url';
-import { proxy } from './constants/constants.js';
+import { proxy, guiInfoStatusTypes } from './constants/constants.js';
 
 // Do NOT remove. These import statements will be used when the custom flow scan is run from the GUI app
 import { chromium } from 'playwright';
@@ -63,7 +63,9 @@ const playwrightAxeGenerator = async data => {
     import { createAndUpdateResultsFolders, createDetailsAndLogs, createScreenshotsFolder, cleanUp, getStoragePath } from '#root/utils.js';
     import constants, {
         getIntermediateScreenshotsPath,
-        getExecutablePath, removeQuarantineFlag
+        getExecutablePath,
+        removeQuarantineFlag,
+        guiInfoStatusTypes,
     } from '#root/constants/constants.js';
     import fs from 'fs';
     import path from 'path';
@@ -71,7 +73,7 @@ const playwrightAxeGenerator = async data => {
     import { isSkippedUrl, submitForm, getBlackListedPatterns } from '#root/constants/common.js';
     import { spawnSync } from 'child_process';
     import safe from 'safe-regex';
-    import { consoleLogger, silentLogger } from '#root/logs.js';
+    import { consoleLogger, silentLogger, guiInfoLog } from '#root/logs.js';
 
   `;
   const block1 = `
@@ -260,9 +262,10 @@ const processPage = async page => {
     const scanRequired = await checkIfScanRequired(page);
     
     if (scanRequired) {
-      if (process.env.RUNNING_FROM_PH_GUI) {
-        console.log("Electron crawling::", urlsCrawled.scanned.length, "::scanned::", pageUrl);
-      }
+      guiInfoLog(guiInfoStatusTypes.SCANNED, {
+        numScanned: urlsCrawled.scanned.length,
+        urlScanned: pageUrl,
+      });
       await runAxeScan(${needsReviewItems}, page);
     }
   }
@@ -321,9 +324,7 @@ const clickFunc = async (elem,page) => {
 `;
 
   const block2 = ` 
-    if (process.env.RUNNING_FROM_PH_GUI) {
-      console.log('Electron scan completed');
-    }
+    guiInfoLog(guiInfoStatusTypes.COMPLETED);
     return urlsCrawled
       } catch (e) {
         console.error('Error: ', e);

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -343,7 +343,7 @@ const clickFunc = async (elem,page) => {
                   : customDevice || deviceChosen || 'Desktop',
               )}, 
               urlsCrawled.scanned, 
-              ${formatScriptStringVar(customFlowLabel)}
+              ${formatScriptStringVar(customFlowLabel || 'Custom Flow')}
             );
 
   await submitForm(

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -91,11 +91,17 @@ const urlsCrawled = { ...constants.urlsCrawledObj };
 const { dataset } = await createCrawleeSubFolders(${formatScriptStringVar(randomToken)});
 
 let blacklistedPatterns = null;
+let exclusionsFile = null;
 
-if ("${blacklistedPatternsFilename}") {
-  const rawPatterns = fs.readFileSync("${blacklistedPatternsFilename}").toString();
+if (fs.existsSync('exclusions.txt')){
+  exclusionsFile = 'exclusions.txt'
+} else if ("${blacklistedPatternsFilename}"){
+  exclusionsFile = "${blacklistedPatternsFilename}"
+}
+
+if (exclusionsFile) {
+  const rawPatterns = fs.readFileSync(exclusionsFile).toString();
   blacklistedPatterns = rawPatterns.split('\\n').filter(pattern => pattern.trim() !== '');
-  console.log("blacklistedPatterns: ", blacklistedPatterns)
 
   let unsafe = blacklistedPatterns.filter(function (pattern) {
     return !safe(pattern);
@@ -106,7 +112,7 @@ if ("${blacklistedPatternsFilename}") {
       "Unsafe expressions detected: " +
       unsafe +
       " Please revise " +
-      "${blacklistedPatternsFilename}";
+      exclusionsFile;
     consoleLogger.error(unsafeExpressionsError);
     silentLogger.error(unsafeExpressionsError);
     process.exit(1);

--- a/runCustomFlowFromGUI.js
+++ b/runCustomFlowFromGUI.js
@@ -7,14 +7,14 @@ import {
   createDetailsAndLogs,
   createScreenshotsFolder,
   cleanUp,
-  getStoragePath
+  getStoragePath,
 } from '#root/utils.js';
 import constants, {
   getIntermediateScreenshotsPath,
   getExecutablePath,
   removeQuarantineFlag,
 } from '#root/constants/constants.js';
-import { isSkippedUrl, submitForm } from '#root/constants/common.js';
+import { isSkippedUrl, submitForm, isBlacklistedFileExtensions } from '#root/constants/common.js';
 import { spawnSync } from 'child_process';
 import { getDefaultChromeDataDir, getDefaultEdgeDataDir } from './constants/constants.js';
 import { argv } from 'process';
@@ -35,7 +35,7 @@ console.log(argv);
 console.log(generatedScript);
 const genScriptString = fs.readFileSync(generatedScript, 'utf-8');
 const genScriptCompleted = new Promise((resolve, reject) => {
-    eval(`(async () => {
+  eval(`(async () => {
         try {
             ${genScriptString} 
             resolve(); 

--- a/runCustomFlowFromGUI.js
+++ b/runCustomFlowFromGUI.js
@@ -1,5 +1,14 @@
-import { chromium, webkit } from 'playwright';
+import { chromium, webkit, devices } from 'playwright';
 import { getComparator } from 'playwright-core/lib/utils';
+import { spawnSync, execSync } from 'child_process';
+import { argv } from 'process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import readline from 'readline';
+import safe from 'safe-regex';
+import printMessage from 'print-message';
 import { createCrawleeSubFolders, runAxeScript } from '#root/crawlers/commonCrawlerFunc.js';
 import { generateArtifacts } from '#root/mergeAxeResults.js';
 import {
@@ -10,25 +19,16 @@ import {
   getStoragePath,
 } from '#root/utils.js';
 import constants, {
+  proxy,
   getIntermediateScreenshotsPath,
   getExecutablePath,
   removeQuarantineFlag,
+  getDefaultChromeDataDir,
+  getDefaultEdgeDataDir,
+  guiInfoStatusTypes,
 } from '#root/constants/constants.js';
-import { isSkippedUrl, submitForm, isBlacklistedFileExtensions } from '#root/constants/common.js';
-import { spawnSync } from 'child_process';
-import { getDefaultChromeDataDir, getDefaultEdgeDataDir } from './constants/constants.js';
-import { argv } from 'process';
-import { execSync } from 'child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import readline from 'readline';
-import safe from 'safe-regex';
-import { devices } from 'playwright';
-import { consoleLogger, silentLogger } from './logs.js';
-import { fileURLToPath } from 'url';
-import { proxy } from './constants/constants.js';
-import printMessage from 'print-message';
+import { isSkippedUrl, submitForm, getBlackListedPatterns } from '#root/constants/common.js';
+import { consoleLogger, silentLogger, guiInfoLog } from './logs.js';
 
 const generatedScript = argv[2];
 console.log(argv);

--- a/runCustomFlowFromGUI.js
+++ b/runCustomFlowFromGUI.js
@@ -7,7 +7,6 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import readline from 'readline';
-import safe from 'safe-regex';
 import printMessage from 'print-message';
 import { createCrawleeSubFolders, runAxeScript } from '#root/crawlers/commonCrawlerFunc.js';
 import { generateArtifacts } from '#root/mergeAxeResults.js';


### PR DESCRIPTION
This PR adds...
- Create -x flag for node cli.js to accept user input for txt file path
- Include file path validation to check for absolute and relative paths and whether file exists
- Use regex and exact match for strings in txt file to exclude domains to scan

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
