### PR TITLE
Handle empty results when parsing for csv report

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -162,6 +162,7 @@ const writeCsv = async (pageResults, storagePath) => {
         }
       }
     }
+    if (results.length === 0) return {};
     return results;
   };
   const opts = {
@@ -261,7 +262,7 @@ const pushResults = async (pageResults, allIssues) => {
   allIssues.topFiveMostIssues.push({ url, pageTitle, totalIssues: totalIssuesInPage.size });
 
   ['mustFix', 'goodToFix', 'passed'].forEach(category => {
-    if (!pageResults[category]) return; 
+    if (!pageResults[category]) return;
     const { totalItems, rules } = pageResults[category];
     const currCategoryFromAllIssues = allIssues.items[category];
 


### PR DESCRIPTION
This PR adds... 
- Handle empty results when parsing json to generate csv report

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
