### PR TITLE
Fix error in flattening pdf scan result for csv report

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -125,6 +125,10 @@ const writeResults = async (allissues, storagePath, jsonFilename = 'compiledResu
 
 const writeCsv = async (pageResults, storagePath) => {
   const csvOutput = createWriteStream(`${storagePath}/reports/report.csv`, { encoding: 'utf8' });
+  const formatPageViolation = pageNum => {
+    if (pageNum < 0) return 'Document';
+    return `Page ${pageNum}`;
+  };
   const flattenResult = item => {
     const results = [];
     const baseObj = { url: item.url };
@@ -146,7 +150,8 @@ const writeCsv = async (pageResults, storagePath) => {
           const { html, message, page } = item;
           const howToFix = message.replace(/(\r\n|\n|\r)/g, ' '); // remove newlines
 
-          const violation = html ? html : page;
+          // page is a number, not string
+          const violation = html ? html : formatPageViolation(page);
           const context = violation.replace(/(\r\n|\n|\r)/g, ''); // remove newlines
           results.push({
             id: crypto.randomUUID(),


### PR DESCRIPTION
This PR adds...
- Convert page field from number to string for pdf scan results

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
