### PR TITLE
Fix to display version num in report for custom flow scans from GUI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -316,7 +316,6 @@ const scanInit = async argvs => {
   data.userDataDirectory = clonedDataDir;
 
   printMessage([`Purple HATS version: ${appVersion}`, 'Starting scan...'], messageOptions);
-  constants.appVersion = appVersion;
 
   if (argvs.scanner === constants.scannerTypes.custom) {
     try {

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -7,7 +7,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import ejs, { compile } from 'ejs';
 import constants from './constants/constants.js';
-import { getCurrentTime, getStoragePath } from './utils.js';
+import { getCurrentTime, getStoragePath, getVersion } from './utils.js';
 import { consoleLogger, silentLogger } from './logs.js';
 import itemTypeDescription from './constants/itemTypeDescription.js';
 import { chromium } from 'playwright';
@@ -412,7 +412,7 @@ export const generateArtifacts = async (
   pagesScanned,
   customFlowLabel,
 ) => {
-  const phAppVersion = constants.appVersion;
+  const phAppVersion = getVersion();
   const storagePath = getStoragePath(randomToken);
   const directory = `${storagePath}/${constants.allIssueFileName}`;
   const allIssues = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8808,7 +8808,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
+        "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
       "dependencies": {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Fix for undefined version number in report when running custom flow from GUI 
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [X] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
