### PR TITLE
Handle i flag in node index

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ const runScan = async (answers) => {
   deleteClonedProfiles(browserToRun);
   answers.browserToRun = browserToRun; 
   answers.nameEmail = `${userData.name}:${userData.email}`;
-
+  answers.fileTypes = 'html-only';
+  
   const data = prepareData(answers);
   clonedDataDir = getClonedProfilesWithRandomToken(data.browser, data.randomToken); 
   data.userDataDirectory = clonedDataDir; 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Set i flag to default value 'html-only' when running from node index
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [X] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
