### PR TITLE
Hide Purple AI in report if it is not reachable (e.g. on proxy or offline)

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -373,6 +373,7 @@ export const generateArtifacts = async (
       goodToFix: { description: itemTypeDescription.goodToFix, totalItems: 0, rules: {} },
       passed: { description: itemTypeDescription.passed, totalItems: 0, rules: {} },
     },
+    proxy: constants.proxy
   };
   const allFiles = await extractFileNames(directory);
 

--- a/static/ejs/partials/scripts/categorySummary.ejs
+++ b/static/ejs/partials/scripts/categorySummary.ejs
@@ -38,7 +38,7 @@
     scanItems[category].rules.forEach((rule, index) => {
       const buttonAriaLabel = `${rule.description}, ${rule.totalItems} occurrences`;
       const purpleAiSvgId = `${category}-${rule.rule}-${index}`;
-      const isPurpleAiRule = purpleAiRules.includes(rule.rule);
+      const isPurpleAiRule = purpleAiRules.includes(rule.rule) && showPurpleAi;
 
       const ruleItem = createElementFromString(`
         <li>

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -85,7 +85,7 @@ category summary is clicked %>
     `),
     );
 
-    if (purpleAiRules.includes(selectedRule.rule)) {
+    if (purpleAiRules.includes(selectedRule.rule) && showPurpleAi) {
       document.querySelector('#expandedRuleAiFeedback').style.display = 'block';
     } else {
       document.querySelector('#expandedRuleAiFeedback').style.display = 'none';
@@ -218,7 +218,7 @@ category summary is clicked %>
         const buttonDivForAiFeedback = `${buttonAIId}-${index}`;
         const aiErrorDiv = `${errorAIId}-${index}`;
         let itemCard;
-        const isPurpleAiRule = purpleAiRules.includes(ruleInCategory.rule);
+        const isPurpleAiRule = purpleAiRules.includes(ruleInCategory.rule) && showPurpleAi;
         let purpleAiQueryLabel;
         if (isPurpleAiRule) {
           purpleAiQueryLabel = await checkPurpleAiQueryLabel(ruleInCategory.rule, item.html);

--- a/static/ejs/partials/scripts/utils.ejs
+++ b/static/ejs/partials/scripts/utils.ejs
@@ -232,6 +232,21 @@
     getRuleIdData: (ruleId) => `https://govtechsg.github.io/purple-ai/results/${ruleId}.json`
   }
 
+  const hasProxy = `<%=proxy%>`;
+
+  const checkPurpleAiAvail = async () => {
+    // check if catalog is empty 
+    return api(apiUrls.catalog).then(catalogData => {
+      try {
+        const catalogHasData = Object.keys(catalogData).length > 1;
+        return catalogHasData;
+      } catch (e) {
+        console.error('Unable to fetch Purple AI catalog');
+        return false; 
+      }
+    })
+  }
+
   const checkPurpleAiQueryLabel = async (ruleId, ruleHtml) => {
     return api(apiUrls.catalog).then(catalogData => {
         // no information for current rule

--- a/static/ejs/partials/scripts/utils.ejs
+++ b/static/ejs/partials/scripts/utils.ejs
@@ -236,15 +236,15 @@
 
   const checkPurpleAiAvail = async () => {
     // check if catalog is empty 
-    return api(apiUrls.catalog).then(catalogData => {
-      try {
+    try {
+      return api(apiUrls.catalog).then(catalogData => {
         const catalogHasData = Object.keys(catalogData).length > 1;
         return catalogHasData;
-      } catch (e) {
-        console.error('Unable to fetch Purple AI catalog');
-        return false; 
-      }
-    })
+      })
+    } catch (e) {
+      console.error('Unable to fetch Purple AI catalog');
+      return false; 
+    }
   }
 
   const checkPurpleAiQueryLabel = async (ruleId, ruleHtml) => {

--- a/static/ejs/report.ejs
+++ b/static/ejs/report.ejs
@@ -42,6 +42,15 @@
     };
     document.addEventListener('DOMContentLoaded', initTooltips);
   </script>
+  <script>
+    let showPurpleAi = false;
+    async function checkToShowPurpleAi () {
+      if (!hasProxy) {
+        showPurpleAi = await checkPurpleAiAvail();
+      }
+    }
+    checkToShowPurpleAi();
+  </script>
 </body>
 
 </html>

--- a/static/ejs/report.ejs
+++ b/static/ejs/report.ejs
@@ -46,7 +46,7 @@
     let showPurpleAi = false;
     async function checkToShowPurpleAi () {
       if (!hasProxy) {
-        showPurpleAi = await checkPurpleAiAvail();
+          showPurpleAi = await checkPurpleAiAvail();
       }
     }
     checkToShowPurpleAi();


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Hide Purple AI functionality in report when catalog is empty or when there is proxy

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [X] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
