### PR TITLE
Run x64 node to fix install deps and fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,19 @@ FROM node:lts-alpine
 
 # Installation of packages for purple-hats and chromium
 RUN apk add build-base gcompat g++ make python3 zip bash git chromium openjdk11-jre
+RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache --virtual .build-deps \
+	build-base \
+	g++ \
+	cairo-dev \
+	jpeg-dev \
+	pango-dev \
+	giflib-dev
+RUN apk add --no-cache --virtual .runtime-deps \
+    	cairo \
+	jpeg \
+	pango \
+	giflib
 
 # Installation of VeraPDF
 RUN echo $'<?xml version="1.0" encoding="UTF-8" standalone="no"?> \n\
@@ -42,6 +55,9 @@ ENV PATH="/opt/verapdf:${PATH}"
 
 # Install dependencies
 RUN npm ci --omit=dev
+
+# cleanup build deps
+RUN apk del .build-deps
 
 # Install Playwright browsers
 RUN npx playwright install chromium webkit

--- a/scripts/hats_shell.sh
+++ b/scripts/hats_shell.sh
@@ -4,11 +4,17 @@ echo "hats Shell - Created By younglim - NO WARRANTY PROVIDED"
 echo "================================================================"
 echo ""
 
+echo "Running as $(uname -m)"
+
 CURR_FOLDERNAME=$(basename "$PWD")
 if [[ $CURR_FOLDERNAME = "scripts" ]]; then
   cd ..
   CURR_FOLDERNAME=$(basename "$PWD")
 fi
+
+# Get current shell command
+SHELL_COMMAND=$(ps -o comm= -p $$)
+SHELL_NAME="${SHELL_COMMAND#-}"
 
 if [[ $(uname -m) == 'arm64' ]]; then
     export ROSETTA2_STATUS_RESULT=$(/usr/bin/pgrep -q oahd && echo true || echo false)
@@ -16,36 +22,40 @@ if [[ $(uname -m) == 'arm64' ]]; then
         echo "Installing Rosetta 2 dependency"
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
     fi
-fi
 
-echo "INFO: Setting path to node for this session"
-if [[ $(uname -m) == 'arm64' ]]; then
-    export PATH_TO_NODE="$(pwd)/nodejs-mac-arm64/bin"
-    export PATH="$PATH_TO_NODE:$PATH" 
+    arch -x86_64 $SHELL_NAME "$0" "$@"
+    
 else
-    export PATH_TO_NODE="$(pwd)/nodejs-mac-x64/bin"
-    export PATH="$PATH_TO_NODE:$PATH"
+
+    echo "INFO: Setting path to node for this session"
+    if [[ $(uname -m) == 'arm64' ]]; then
+        export PATH_TO_NODE="$(pwd)/nodejs-mac-arm64/bin"
+        export PATH="$PATH_TO_NODE:$PATH" 
+    else
+        export PATH_TO_NODE="$(pwd)/nodejs-mac-x64/bin"
+        export PATH="$PATH_TO_NODE:$PATH"
+    fi
+
+    echo "INFO: Set path to node_modules for this session"
+    if find ./purple-hats -name "node_modules" -maxdepth 1 -type l -ls &> /dev/null; then
+        export PATH="$PWD/purple-hats/node_modules/.bin:$PATH"
+    else
+        export PATH="$PWD/node_modules/.bin:$PATH"
+    fi
+
+    echo "INFO: Set path to Java JRE"
+    export JAVA_HOME="$(PWD)/jre"
+    export PATH="$JAVA_HOME/bin:$PATH"
+
+    echo "INFO: Set path to VeraPDF"
+    export PATH="$PWD/verapdf:$PATH"
+
+    echo "INFO: Set path to Playwright cache for this session"
+    export PLAYWRIGHT_BROWSERS_PATH="$PWD/ms-playwright"
+    export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+
+    echo "INFO: Removing com.apple.quarantine attributes for required binaries to run"
+    xattr -rd com.apple.quarantine . &>/dev/null
+
+    $@
 fi
-
-echo "INFO: Set path to node_modules for this session"
-if find ./purple-hats -name "node_modules" -maxdepth 1 -type l -ls &> /dev/null; then
-    export PATH="$PWD/purple-hats/node_modules/.bin:$PATH"
-else
-    export PATH="$PWD/node_modules/.bin:$PATH"
-fi
-
-echo "INFO: Set path to Java JRE"
-export JAVA_HOME="$(PWD)/jre"
-export PATH="$JAVA_HOME/bin:$PATH"
-
-echo "INFO: Set path to VeraPDF"
-export PATH="$PWD/verapdf:$PATH"
-
-echo "INFO: Set path to Playwright cache for this session"
-export PLAYWRIGHT_BROWSERS_PATH="$PWD/ms-playwright"
-export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
-
-echo "INFO: Removing com.apple.quarantine attributes for required binaries to run"
-xattr -rd com.apple.quarantine . &>/dev/null
-
-$@

--- a/scripts/install_purple_dependencies.command
+++ b/scripts/install_purple_dependencies.command
@@ -11,12 +11,6 @@ fi
 
 PROJECT_DIR="$PWD"
 
-if ! [ -f nodejs-mac-arm64/bin/node ]; then
-  echo "Downloading NodeJS LTS (ARM64)"
-  curl -o ./nodejs-mac-arm64.tar.gz --create-dirs https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-arm64.tar.gz  
-  mkdir nodejs-mac-arm64 && tar -xzf nodejs-mac-arm64.tar.gz -C nodejs-mac-arm64 --strip-components=1 && rm ./nodejs-mac-arm64.tar.gz
-fi
-
 if ! [ -f nodejs-mac-x64/bin/node ]; then
   echo "Downloading NodeJS LTS (x64)"
   curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-x64.tar.gz     

--- a/scripts/install_purple_dependencies.command
+++ b/scripts/install_purple_dependencies.command
@@ -42,8 +42,6 @@ if ! [ -f jre/bin/java ]; then
 
 fi
 
-source "${__dir}/hats_shell.sh"
-
 if ! [ -f verapdf/verapdf ]; then
   echo "Downloading VeraPDF"
   if [ -d "./verapdf" ]; then rm -Rf ./verapdf; fi
@@ -70,12 +68,8 @@ if [ -d "node_modules" ]; then
   rm -rf node_modules 
 fi
 
-echo "Installing Node dependencies to $PWD"
-npm ci --force
-
-echo "Installing Playwright browsers"
-npx playwright install webkit
-
+echo "Installing Node dependencies to $PWD and Installing Playwright browsers"
+source "${__dir}/hats_shell.sh" npm ci --force; npx playwright install webkit
 
 
 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Use x64 version of Node to install required deps on macos
- Update hats_shell.sh on macos
- Add deps for node-canvas to Dockerfile

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
