### PR TITLE
Update node from v18.12.0 to v18.18.0 to fix macOS Sonoma runtime issue

### DIFF
--- a/scripts/install_purple_dependencies.command
+++ b/scripts/install_purple_dependencies.command
@@ -13,8 +13,9 @@ PROJECT_DIR="$PWD"
 
 if ! [ -f nodejs-mac-x64/bin/node ]; then
   echo "Downloading NodeJS LTS (x64)"
-  curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v18.12.1/node-v18.12.1-darwin-x64.tar.gz     
+  curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v18.18.0/node-v18.18.0-darwin-x64.tar.gz     
   mkdir nodejs-mac-x64 && tar -xzf nodejs-mac-x64.tar.gz -C nodejs-mac-x64 --strip-components=1 && rm ./nodejs-mac-x64.tar.gz
+  rm node-*-darwin-x64.tar.gz
 fi
 
 export CORRETTO_BASEDIR="$HOME/Library/Application Support/Purple HATS"

--- a/scripts/install_purple_dependencies.ps1
+++ b/scripts/install_purple_dependencies.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 # Install NodeJS binaries
 if (-Not (Test-Path nodejs-win\node.exe)) {
     Write-Output "Downloading Node"
-    Invoke-WebRequest -o ./nodejs-win.zip "https://nodejs.org/dist/v18.12.1/node-v18.12.1-win-x64.zip"     
+    Invoke-WebRequest -o ./nodejs-win.zip "https://nodejs.org/dist/v18.18.0/node-v18.18.0-win-x64.zip"     
     
     Write-Output "Unzip Node"
     Expand-Archive .\nodejs-win.zip -DestinationPath .


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Update node from v18.12.0 to v18.18.0 to fix Sonoma runtime issue

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
