### PR TITLE
Remove PDF Screenshots functionality due to installation issue on M1 Mac

### DIFF
--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -16,7 +16,7 @@ import {
   isSkippedUrl,
 } from '../constants/common.js';
 import { areLinksEqual } from '../utils.js';
-import { handlePdfDownload, runPdfScan, mapPdfScanResults, doPdfScreenshots } from './pdfScanFunc.js';
+import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
 import fs from 'fs';
 import { guiInfoLog } from '../logs.js';
 import { chromium } from 'playwright';
@@ -139,7 +139,6 @@ const crawlDomain = async (
       enqueueLinks,
       enqueueLinksByClickingElements,
     }) => {
-
       // loadedUrl is the URL after redirects
       const actualUrl = request.loadedUrl || request.url;
 
@@ -194,7 +193,7 @@ const crawlDomain = async (
           numScanned: urlsCrawled.scanned.length,
           urlScanned: request.url,
         });
-        urlsCrawled.invalid.push({url: request.url});
+        urlsCrawled.invalid.push({ url: request.url });
         return;
       }
 
@@ -266,8 +265,11 @@ const crawlDomain = async (
       }
     },
     failedRequestHandler: async ({ request }) => {
-      guiInfoLog(guiInfoStatusTypes.ERROR, { numScanned: urlsCrawled.scanned.length, urlScanned: request.url });
-      urlsCrawled.error.push({url: request.url});
+      guiInfoLog(guiInfoStatusTypes.ERROR, {
+        numScanned: urlsCrawled.scanned.length,
+        urlScanned: request.url,
+      });
+      urlsCrawled.error.push({ url: request.url });
       crawlee.log.error(`Failed Request - ${request.url}: ${request.errorMessages}`);
     },
     maxRequestsPerCrawl,
@@ -287,11 +289,11 @@ const crawlDomain = async (
     const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
 
     // get screenshots from pdf docs
-    if (includeScreenshots) {
-      await Promise.all(pdfResults.map(
-        async result => await doPdfScreenshots(randomToken, result)
-      ));
-    }
+    // if (includeScreenshots) {
+    //   await Promise.all(pdfResults.map(
+    //     async result => await doPdfScreenshots(randomToken, result)
+    //   ));
+    // }
 
     // push results for each pdf document to key value store
     await Promise.all(pdfResults.map(result => dataset.pushData(result)));

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -19,7 +19,6 @@ import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
 import fs from 'fs';
 import { guiInfoLog } from '../logs.js';
-import { doPdfScreenshots } from './pdfScanFunc.js';
 
 const crawlSitemap = async (
   sitemapUrl,
@@ -190,8 +189,11 @@ const crawlSitemap = async (
       }
     },
     failedRequestHandler: async ({ request }) => {
-      guiInfoLog(guiInfoStatusTypes.ERROR, { numScanned: urlsCrawled.scanned.length, urlScanned: request.url });
-      urlsCrawled.error.push({url: request.url});
+      guiInfoLog(guiInfoStatusTypes.ERROR, {
+        numScanned: urlsCrawled.scanned.length,
+        urlScanned: request.url,
+      });
+      urlsCrawled.error.push({ url: request.url });
       crawlee.log.error(`Failed Request - ${request.url}: ${request.errorMessages}`);
     },
     maxRequestsPerCrawl,
@@ -213,11 +215,11 @@ const crawlSitemap = async (
     const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
 
     // get screenshots from pdf docs
-    if (includeScreenshots) {
-      await Promise.all(pdfResults.map(
-        async result => await doPdfScreenshots(randomToken, result)
-      ));
-    }
+    // if (includeScreenshots) {
+    //   await Promise.all(pdfResults.map(
+    //     async result => await doPdfScreenshots(randomToken, result)
+    //   ));
+    // }
 
     // push results for each pdf document to key value store
     await Promise.all(pdfResults.map(result => dataset.pushData(result)));

--- a/crawlers/pdfScanFunc.js
+++ b/crawlers/pdfScanFunc.js
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto';
 import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
-import { getPageFromContext, getPdfScreenshots } from '../screenshotFunc/pdfScreenshotFunc.js';
+import { getPageFromContext } from '../screenshotFunc/pdfScreenshotFunc.js';
 import { ensureDirSync } from 'fs-extra';
 
 const require = createRequire(import.meta.url);
@@ -270,21 +270,21 @@ const transformRule = async (rule, filePath) => {
   return [ruleId, transformed];
 };
 
-export const doPdfScreenshots = async (randomToken, result) => {
-  const { filePath, pageTitle } = result;
-  const formattedPageTitle = pageTitle.replaceAll(" ", "_").split('.')[0];
-  const screenshotsDir = path.join(randomToken, 'elemScreenshots', 'pdf');
+// export const doPdfScreenshots = async (randomToken, result) => {
+//   const { filePath, pageTitle } = result;
+//   const formattedPageTitle = pageTitle.replaceAll(" ", "_").split('.')[0];
+//   const screenshotsDir = path.join(randomToken, 'elemScreenshots', 'pdf');
 
-  ensureDirSync(screenshotsDir);
+//   ensureDirSync(screenshotsDir);
 
-  for (const category of ['mustFix', 'goodToFix']) {
-    const ruleItems = Object.entries(result[category].rules);
-    for (const [ruleId, ruleInfo] of ruleItems) {
-      const { items } = ruleInfo;
-      const filename = `${formattedPageTitle}-${category}-${ruleId}`;
-      const screenshotPath = path.join(screenshotsDir, filename);
-      const newItems = await getPdfScreenshots(filePath, items, screenshotPath);
-      ruleInfo.items = newItems;
-    }
-  }
-};
+//   for (const category of ['mustFix', 'goodToFix']) {
+//     const ruleItems = Object.entries(result[category].rules);
+//     for (const [ruleId, ruleInfo] of ruleItems) {
+//       const { items } = ruleInfo;
+//       const filename = `${formattedPageTitle}-${category}-${ruleId}`;
+//       const screenshotPath = path.join(screenshotsDir, filename);
+//       const newItems = await getPdfScreenshots(filePath, items, screenshotPath);
+//       ruleInfo.items = newItems;
+//     }
+//   }
+// };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@json2csv/node": "^7.0.3",
         "axe-core": "^4.6.2",
         "axios": "^1.2.2",
-        "canvas": "^2.11.2",
         "cheerio": "^1.0.0-rc.12",
         "crawlee": "^3.5.2",
         "ejs": "^3.1.9",
@@ -1868,6 +1867,8 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -1887,6 +1888,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1898,6 +1901,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -1912,6 +1917,8 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1920,6 +1927,8 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1933,7 +1942,9 @@
     "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2207,7 +2218,9 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -2352,12 +2365,16 @@
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -2847,6 +2864,8 @@
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
       "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -2925,6 +2944,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3090,6 +3111,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -3141,7 +3164,9 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-type": {
       "version": "1.0.5",
@@ -3395,12 +3420,16 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4431,6 +4460,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4442,6 +4473,8 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4452,7 +4485,9 @@
     "node_modules/fs-minipass/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4510,6 +4545,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -4846,7 +4883,9 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/header-generator": {
       "version": "2.1.38",
@@ -5039,6 +5078,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6652,6 +6692,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -6664,6 +6706,8 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6674,12 +6718,16 @@
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -6703,7 +6751,9 @@
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -6732,6 +6782,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6750,17 +6802,23 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6781,6 +6839,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -6827,6 +6887,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -6854,6 +6916,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7178,6 +7242,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7726,6 +7791,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "devOptional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7740,6 +7806,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7749,6 +7816,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "devOptional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7768,6 +7836,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7919,7 +7988,9 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7978,12 +8049,16 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -7994,6 +8069,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^2.0.0"
       },
@@ -8005,6 +8082,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -8286,6 +8365,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
       "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -8302,6 +8383,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8309,7 +8392,9 @@
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -8850,6 +8935,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -10506,6 +10593,8 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -10522,6 +10611,8 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -10530,6 +10621,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "semver": "^6.0.0"
           },
@@ -10537,7 +10630,9 @@
             "semver": {
               "version": "6.3.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+              "optional": true,
+              "peer": true
             }
           }
         },
@@ -10545,6 +10640,8 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
           "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10552,7 +10649,9 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -10795,7 +10894,9 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
     },
     "acorn": {
       "version": "8.10.0",
@@ -10894,12 +10995,16 @@
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "optional": true,
+      "peer": true
     },
     "are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -11237,6 +11342,8 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
       "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -11293,7 +11400,9 @@
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "optional": true,
+      "peer": true
     },
     "ci-info": {
       "version": "3.8.0",
@@ -11428,7 +11537,9 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "optional": true,
+      "peer": true
     },
     "colorspace": {
       "version": "1.1.4",
@@ -11461,7 +11572,9 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "optional": true,
+      "peer": true
     },
     "content-type": {
       "version": "1.0.5",
@@ -11633,12 +11746,16 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "optional": true,
+      "peer": true
     },
     "detect-libc": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "optional": true,
+      "peer": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12407,6 +12524,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "minipass": "^3.0.0"
       },
@@ -12415,6 +12534,8 @@
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
           "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -12422,7 +12543,9 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -12466,6 +12589,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -12701,7 +12826,9 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "optional": true,
+      "peer": true
     },
     "header-generator": {
       "version": "2.1.38",
@@ -12831,6 +12958,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -14053,6 +14181,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -14062,6 +14192,8 @@
           "version": "3.3.6",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
           "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -14069,14 +14201,18 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true,
+          "peer": true
         }
       }
     },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "optional": true,
+      "peer": true
     },
     "ms": {
       "version": "2.1.2",
@@ -14091,7 +14227,9 @@
     "nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true,
+      "peer": true
     },
     "nanoid": {
       "version": "3.3.6",
@@ -14108,6 +14246,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -14115,17 +14255,23 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "optional": true,
+          "peer": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "optional": true,
+          "peer": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -14148,6 +14294,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "abbrev": "1"
       }
@@ -14176,6 +14324,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -14199,7 +14349,9 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "optional": true,
+      "peer": true
     },
     "object-inspect": {
       "version": "1.12.3",
@@ -14426,7 +14578,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "devOptional": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -14798,6 +14951,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "devOptional": true,
       "requires": {
         "glob": "^7.1.3"
       },
@@ -14806,6 +14960,7 @@
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "devOptional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14815,6 +14970,7 @@
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
           "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "devOptional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -14828,6 +14984,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "devOptional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14929,7 +15086,9 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "optional": true,
+      "peer": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -14965,12 +15124,16 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "optional": true,
+      "peer": true
     },
     "simple-get": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -14981,6 +15144,8 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
           "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "mimic-response": "^2.0.0"
           }
@@ -14988,7 +15153,9 @@
         "mimic-response": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -15209,6 +15376,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
       "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -15221,12 +15390,16 @@
         "minipass": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+          "optional": true,
+          "peer": true
         },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -15640,6 +15813,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/purple-hats",
   "main": "npmIndex.js",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "type": "module",
   "imports": {
     "#root/*.js": "./*.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@json2csv/node": "^7.0.3",
     "axe-core": "^4.6.2",
     "axios": "^1.2.2",
-    "canvas": "^2.11.2",
     "cheerio": "^1.0.0-rc.12",
     "crawlee": "^3.5.2",
     "ejs": "^3.1.9",

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -402,10 +402,9 @@ const clickFunc = async (elem,page) => {
 
     // use webkit for recording due to flaky codegen on mobile / specify viewports
     if (os.platform() === 'darwin') {
-      browser = 'webkit';
-      channel = '';
+      // Use Chrome
     } else {
-      // Windows
+      // Use Edge if Chrome cannot be launched on data directory
       if (!getDefaultChromeDataDir()) {
         channel = 'msedge';
       }

--- a/screenshotFunc/pdfScreenshotFunc.js
+++ b/screenshotFunc/pdfScreenshotFunc.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import pdfjs from 'pdfjs-dist';
 import fs from 'fs';
-import Canvas from 'canvas';
-import assert from 'assert';
+// import Canvas from 'canvas';
+// import assert from 'assert';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { silentLogger } from '../logs.js';
@@ -13,163 +13,163 @@ const __dirname = path.dirname(__filename);
 // CONSTANTS
 const BBOX_PADDING = 50;
 
-function NodeCanvasFactory() {}
-NodeCanvasFactory.prototype = {
-  create: function NodeCanvasFactory_create(width, height) {
-    assert(width > 0 && height > 0, 'Invalid canvas size');
-    const canvas = Canvas.createCanvas(width, height);
-    const context = canvas.getContext('2d');
-    return {
-      canvas,
-      context,
-    };
-  },
+// function NodeCanvasFactory() {}
+// NodeCanvasFactory.prototype = {
+//   create: function NodeCanvasFactory_create(width, height) {
+//     assert(width > 0 && height > 0, 'Invalid canvas size');
+//     const canvas = Canvas.createCanvas(width, height);
+//     const context = canvas.getContext('2d');
+//     return {
+//       canvas,
+//       context,
+//     };
+//   },
 
-  reset: function NodeCanvasFactory_reset(canvasAndContext, width, height) {
-    assert(canvasAndContext.canvas, 'Canvas is not specified');
-    assert(width > 0 && height > 0, 'Invalid canvas size');
-    canvasAndContext.canvas.width = width;
-    canvasAndContext.canvas.height = height;
-  },
+//   reset: function NodeCanvasFactory_reset(canvasAndContext, width, height) {
+//     assert(canvasAndContext.canvas, 'Canvas is not specified');
+//     assert(width > 0 && height > 0, 'Invalid canvas size');
+//     canvasAndContext.canvas.width = width;
+//     canvasAndContext.canvas.height = height;
+//   },
 
-  destroy: function NodeCanvasFactory_destroy(canvasAndContext) {
-    assert(canvasAndContext.canvas, 'Canvas is not specified');
+//   destroy: function NodeCanvasFactory_destroy(canvasAndContext) {
+//     assert(canvasAndContext.canvas, 'Canvas is not specified');
 
-    canvasAndContext.canvas.width = 0;
-    canvasAndContext.canvas.height = 0;
-    canvasAndContext.canvas = null;
-    canvasAndContext.context = null;
-  },
-};
+//     canvasAndContext.canvas.width = 0;
+//     canvasAndContext.canvas.height = 0;
+//     canvasAndContext.canvas = null;
+//     canvasAndContext.context = null;
+//   },
+// };
 
-const canvasFactory = new NodeCanvasFactory();
+// const canvasFactory = new NodeCanvasFactory();
 
-export async function getPdfScreenshots(pdfFilePath, items, screenshotPath) {
-  const newItems = _.cloneDeep(items);
-  const loadingTask = pdfjs.getDocument({
-    url: pdfFilePath,
-    canvasFactory,
-    standardFontDataUrl: path.join(__dirname, '../node_modules/pdfjs-dist/standard_fonts/'),
-    disableFontFace: true,
-    verbosity: 0,
-  });
-  const pdf = await loadingTask.promise;
-  const structureTree = await pdf._pdfInfo.structureTree;
+// export async function getPdfScreenshots(pdfFilePath, items, screenshotPath) {
+//   const newItems = _.cloneDeep(items);
+//   const loadingTask = pdfjs.getDocument({
+//     url: pdfFilePath,
+//     canvasFactory,
+//     standardFontDataUrl: path.join(__dirname, '../node_modules/pdfjs-dist/standard_fonts/'),
+//     disableFontFace: true,
+//     verbosity: 0,
+//   });
+//   const pdf = await loadingTask.promise;
+//   const structureTree = await pdf._pdfInfo.structureTree;
 
-  // save some resources by caching page canvases to be reused by diff violations
-  const pageCanvasCache = {};
+//   // save some resources by caching page canvases to be reused by diff violations
+//   const pageCanvasCache = {};
 
-  // iterate through each violation
-  for (let i = 0; i < newItems.length; i++) {
-    const { context } = newItems[i];
-    const bbox = { location: context };
-    const bboxMap = buildBboxMap([bbox], structureTree);
+//   // iterate through each violation
+//   for (let i = 0; i < newItems.length; i++) {
+//     const { context } = newItems[i];
+//     const bbox = { location: context };
+//     const bboxMap = buildBboxMap([bbox], structureTree);
 
-    for (const [pageNum, bboxList] of Object.entries(bboxMap)) {
-      const page = await pdf.getPage(parseInt(pageNum, 10));
+//     for (const [pageNum, bboxList] of Object.entries(bboxMap)) {
+//       const page = await pdf.getPage(parseInt(pageNum, 10));
 
-      // an array of length 1, containing location of current violation
-      const bboxesWithCoords = await Promise.all([
-        page.getOperatorList(),
-        page.getAnnotations(),
-      ]).then(getBboxesList(bboxList, page));
+//       // an array of length 1, containing location of current violation
+//       const bboxesWithCoords = await Promise.all([
+//         page.getOperatorList(),
+//         page.getAnnotations(),
+//       ]).then(getBboxesList(bboxList, page));
 
-      // Render the page on a Node canvas with 200% scale.
-      const viewport = page.getViewport({ scale: 2.0 });
+//       // Render the page on a Node canvas with 200% scale.
+//       const viewport = page.getViewport({ scale: 2.0 });
 
-      const canvasAndContext =
-        pageCanvasCache[pageNum] ?? canvasFactory.create(viewport.width, viewport.height);
-      if (!pageCanvasCache[pageNum]) {
-        pageCanvasCache[pageNum] = canvasAndContext;
-      }
-      const { canvas: origCanvas, context: origCtx } = canvasAndContext;
+//       const canvasAndContext =
+//         pageCanvasCache[pageNum] ?? canvasFactory.create(viewport.width, viewport.height);
+//       if (!pageCanvasCache[pageNum]) {
+//         pageCanvasCache[pageNum] = canvasAndContext;
+//       }
+//       const { canvas: origCanvas, context: origCtx } = canvasAndContext;
 
-      const renderContext = {
-        canvasContext: origCtx,
-        viewport,
-      };
-      const renderTask = page.render(renderContext); // render pdf page onto a canvas
-      await renderTask.promise;
+//       const renderContext = {
+//         canvasContext: origCtx,
+//         viewport,
+//       };
+//       const renderTask = page.render(renderContext); // render pdf page onto a canvas
+//       await renderTask.promise;
 
-      const finalScreenshotPath = annotateAndSave(
-        origCanvas,
-        screenshotPath,
-        viewport,
-      )(bboxesWithCoords[0]);
+//       const finalScreenshotPath = annotateAndSave(
+//         origCanvas,
+//         screenshotPath,
+//         viewport,
+//       )(bboxesWithCoords[0]);
 
-      newItems[i].screenshotPath = finalScreenshotPath;
-      newItems[i].page = parseInt(pageNum, 10);
+//       newItems[i].screenshotPath = finalScreenshotPath;
+//       newItems[i].page = parseInt(pageNum, 10);
 
-      page.cleanup();
-    }
-  }
-  return newItems;
-}
+//       page.cleanup();
+//     }
+//   }
+//   return newItems;
+// }
 
-const annotateAndSave = (origCanvas, screenshotPath, viewport) => {
-  return ({ location }) => {
-    const [left, bottom, width, height] = location.map(loc => loc * 2); // scale up by 2
-    const rectParams = [left, viewport.height - bottom - height, width, height];
+// const annotateAndSave = (origCanvas, screenshotPath, viewport) => {
+//   return ({ location }) => {
+//     const [left, bottom, width, height] = location.map(loc => loc * 2); // scale up by 2
+//     const rectParams = [left, viewport.height - bottom - height, width, height];
 
-    // create new canvas to annotate so we do not "pollute" the original
-    const { context: highlightCtx, canvas: highlightCanvas } = canvasFactory.create(
-      viewport.width,
-      viewport.height,
-    );
+//     // create new canvas to annotate so we do not "pollute" the original
+//     const { context: highlightCtx, canvas: highlightCanvas } = canvasFactory.create(
+//       viewport.width,
+//       viewport.height,
+//     );
 
-    highlightCtx.drawImage(origCanvas, 0, 0);
-    highlightCtx.fillStyle = 'rgba(0, 255, 255, 0.2)';
-    highlightCtx.fillRect(...rectParams);
+//     highlightCtx.drawImage(origCanvas, 0, 0);
+//     highlightCtx.fillStyle = 'rgba(0, 255, 255, 0.2)';
+//     highlightCtx.fillRect(...rectParams);
 
-    const rectParamsWithPadding = [
-      left - BBOX_PADDING,
-      viewport.height - bottom - height - BBOX_PADDING,
-      width + BBOX_PADDING * 2,
-      height + BBOX_PADDING * 2,
-    ];
+//     const rectParamsWithPadding = [
+//       left - BBOX_PADDING,
+//       viewport.height - bottom - height - BBOX_PADDING,
+//       width + BBOX_PADDING * 2,
+//       height + BBOX_PADDING * 2,
+//     ];
 
-    // create new canvas to crop image
-    const { context: croppedCtx, canvas: croppedCanvas } = canvasFactory.create(
-      rectParamsWithPadding[2],
-      rectParamsWithPadding[3],
-    );
+//     // create new canvas to crop image
+//     const { context: croppedCtx, canvas: croppedCanvas } = canvasFactory.create(
+//       rectParamsWithPadding[2],
+//       rectParamsWithPadding[3],
+//     );
 
-    croppedCtx.drawImage(
-      highlightCanvas,
-      ...rectParamsWithPadding,
-      0,
-      0,
-      rectParamsWithPadding[2],
-      rectParamsWithPadding[3],
-    );
+//     croppedCtx.drawImage(
+//       highlightCanvas,
+//       ...rectParamsWithPadding,
+//       0,
+//       0,
+//       rectParamsWithPadding[2],
+//       rectParamsWithPadding[3],
+//     );
 
-    // convert the canvas to an image
-    const croppedImage = croppedCanvas.toBuffer();
+//     // convert the canvas to an image
+//     const croppedImage = croppedCanvas.toBuffer();
 
-    // save image
-    let counter = 0;
-    let indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
-    let fileExists = fs.existsSync(indexedScreenshotPath);
-    while (fileExists) {
-      counter++;
-      indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
-      fileExists = fs.existsSync(indexedScreenshotPath);
-    }
-    fs.writeFileSync(indexedScreenshotPath, croppedImage, error => {
-      if (error) {
-        silentLogger.error("Error in writing screenshot: " + error);
-      }
-    });
+//     // save image
+//     let counter = 0;
+//     let indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
+//     let fileExists = fs.existsSync(indexedScreenshotPath);
+//     while (fileExists) {
+//       counter++;
+//       indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
+//       fileExists = fs.existsSync(indexedScreenshotPath);
+//     }
+//     fs.writeFileSync(indexedScreenshotPath, croppedImage, error => {
+//       if (error) {
+//         silentLogger.error('Error in writing screenshot: ' + error);
+//       }
+//     });
 
-    canvasFactory.destroy({ canvas: croppedCanvas, context: croppedCtx });
-    canvasFactory.destroy({ canvas: highlightCanvas, context: highlightCtx });
+//     canvasFactory.destroy({ canvas: croppedCanvas, context: croppedCtx });
+//     canvasFactory.destroy({ canvas: highlightCanvas, context: highlightCtx });
 
-    // current screenshot path leads to a temp dir, so modify to save the final file path
-    const [_, ...rest] = indexedScreenshotPath.split(path.sep);
-    const finalScreenshotPath = path.join(...rest);
-    return finalScreenshotPath;
-  };
-};
+//     // current screenshot path leads to a temp dir, so modify to save the final file path
+//     const [_, ...rest] = indexedScreenshotPath.split(path.sep);
+//     const finalScreenshotPath = path.join(...rest);
+//     return finalScreenshotPath;
+//   };
+// };
 
 // Below are methods adapted from
 // https://github.com/veraPDF/verapdf-js-viewer/blob/master/src/services/bboxService.ts
@@ -327,7 +327,7 @@ export const getSelectedPageByLocation = bboxLocation => {
 export const getPageFromContext = async (context, pdfFilePath) => {
   const loadingTask = pdfjs.getDocument({
     url: pdfFilePath,
-    canvasFactory,
+    // canvasFactory,
     standardFontDataUrl: path.join(__dirname, '../node_modules/pdfjs-dist/standard_fonts/'),
     disableFontFace: true,
     verbosity: 0,
@@ -336,11 +336,11 @@ export const getPageFromContext = async (context, pdfFilePath) => {
   const structureTree = await pdf._pdfInfo.structureTree;
   const page = getBboxPage({ location: context }, structureTree);
   return page;
-}
+};
 
 export const getBboxPages = (bboxes, structure) => {
   return bboxes.map(bbox => {
-    getBboxPage(bbox, structure)
+    getBboxPage(bbox, structure);
   });
 };
 

--- a/scripts/hats_shell.command
+++ b/scripts/hats_shell.command
@@ -1,23 +1,11 @@
-#!/bin/bash
-
+#!/bin/zsh
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Get current shell command
 SHELL_COMMAND=$(ps -o comm= -p $$)
 SHELL_NAME="${SHELL_COMMAND#-}"
 CURR_FOLDERNAME="$(dirname "$0")"
-echo "$CURR_FOLDERNAME"
 
-if [[ $(uname -m) == 'arm64' ]]; then
-    export ROSETTA2_STATUS_RESULT=$(/usr/bin/pgrep -q oahd && echo true || echo false)
-    if ! $ROSETTA2_STATUS_RESULT; then   
-        echo "Installing Rosetta 2 dependency"
-        /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-    fi
+cd "$CURR_FOLDERNAME"
 
-    echo "Switching to x86_64 shell"
-    arch -x86_64 $SHELL_NAME "$CURR_FOLDERNAME/hats_shell.sh" $SHELL_NAME
-    
-else
-    $SHELL_NAME "$CURR_FOLDERNAME/hats_shell.sh" $SHELL_NAME
-fi
+$SHELL_NAME "$CURR_FOLDERNAME/hats_shell.sh" $SHELL_NAME

--- a/scripts/hats_shell.sh
+++ b/scripts/hats_shell.sh
@@ -4,13 +4,15 @@ echo "hats Shell - Created By younglim - NO WARRANTY PROVIDED"
 echo "================================================================"
 echo ""
 
-CURR_FOLDERNAME=$(basename "$PWD")
-if [[ "$CURR_FOLDERNAME" = "scripts" ]]; then
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORIGINAL_DIR="$PWD"
+
+CURR_FOLDERNAME="$(basename "$PWD")"
+
+if [ "$CURR_FOLDERNAME" = "scripts" ]; then
   cd ..
   CURR_FOLDERNAME="$(basename "$PWD")"
 fi
-
-__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Get current shell command
 SHELL_COMMAND=$(ps -o comm= -p $$)
@@ -23,35 +25,37 @@ if [[ $(uname -m) == 'arm64' ]]; then
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
     fi
 
-    echo "Switching to x86_64 shell"
-    arch -x86_64 $SHELL_NAME "$0" "$@"
-    
+    echo "INFO: Setting path to node arm64 for this session"
+    export PATH_TO_NODE="$PWD/nodejs-mac-arm64/bin"
+
 else
-
-    echo "INFO: Setting path to node for this session"
-    export PATH_TO_NODE="$__dir/nodejs-mac-x64/bin"
-    export PATH="$PATH_TO_NODE:$PATH"
-
-    echo "INFO: Set path to node_modules for this session"
-    if find ./purple-hats -name "node_modules" -maxdepth 1 -type l -ls &> /dev/null; then
-        export PATH="$__dir/purple-hats/node_modules/.bin:$PATH"
-    else
-        export PATH="$__dir/node_modules/.bin:$PATH"
-    fi
-
-    echo "INFO: Set path to Java JRE"
-    export JAVA_HOME="$__dir/jre"
-    export PATH="$JAVA_HOME/bin:$PATH"
-
-    echo "INFO: Set path to VeraPDF"
-    export PATH="$__dir/verapdf:$PATH"
-
-    echo "INFO: Set path to Playwright cache for this session"
-    export PLAYWRIGHT_BROWSERS_PATH="$__dir/ms-playwright"
-    export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
-
-    echo "INFO: Removing com.apple.quarantine attributes for required binaries to run"
-    xattr -rd com.apple.quarantine . &>/dev/null
-
-    eval "$1"
+    echo "INFO: Setting path to node x64 for this session"
+    export PATH_TO_NODE="$PWD/nodejs-mac-x64/bin"
 fi
+
+
+export PATH="$PATH_TO_NODE:$PATH"
+
+echo "INFO: Set path to node_modules for this session"
+if find ./purple-hats -name "node_modules" -maxdepth 1 -type l -ls &> /dev/null; then
+    export PATH="$PWD/purple-hats/node_modules/.bin:$PATH"
+else
+    export PATH="$PWD/node_modules/.bin:$PATH"
+fi
+
+echo "INFO: Set path to Java JRE"
+export JAVA_HOME="$PWD/jre"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+echo "INFO: Set path to VeraPDF"
+export PATH="$PWD/verapdf:$PATH"
+
+echo "INFO: Set path to Playwright cache for this session"
+export PLAYWRIGHT_BROWSERS_PATH="$PWD/ms-playwright"
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+
+echo "INFO: Removing com.apple.quarantine attributes for required binaries to run"
+xattr -rd com.apple.quarantine . &>/dev/null
+
+cd "$ORIGINAL_DIR"
+$@

--- a/scripts/install_purple_dependencies.command
+++ b/scripts/install_purple_dependencies.command
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+NODE_VERSION="18.18.0"
+
 # Get current shell command
 SHELL_COMMAND=$(ps -o comm= -p $$)
 SHELL_NAME="${SHELL_COMMAND#-}"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CURR_FOLDERNAME="$(basename "$PWD")"
+if [ "$CURR_FOLDERNAME" = "scripts" ]; then
+  cd ..
+  CURR_FOLDERNAME="$(basename "$PWD")"
+fi
 
 if [[ $(uname -m) == 'arm64' ]]; then
     export ROSETTA2_STATUS_RESULT=$(/usr/bin/pgrep -q oahd && echo true || echo false)
@@ -11,78 +22,76 @@ if [[ $(uname -m) == 'arm64' ]]; then
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
     fi
 
-    echo "Switching to x86_64 shell"
-    arch -x86_64 $SHELL_NAME "$0" "$@"
+fi
 
-else 
-  cd "$(dirname "${BASH_SOURCE[0]}")"
-  __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! [ -f nodejs-mac-arm64/bin/node ]; then
+  echo "Downloading NodeJS LTS (ARM64)"
+  curl -o ./nodejs-mac-arm64.tar.gz --create-dirs https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-arm64.tar.gz  
+  mkdir nodejs-mac-arm64
+  tar -xzf nodejs-mac-arm64.tar.gz -C nodejs-mac-arm64 --strip-components=1 && rm ./nodejs-mac-arm64.tar.gz
+  rm nodejs-mac-arm64.tar.gz
+fi
 
-  CURR_FOLDERNAME="$(basename "$PWD")"
-  if [ "$CURR_FOLDERNAME" = "scripts" ]; then
-    cd ..
-    CURR_FOLDERNAME="$(basename "$PWD")"
+if ! [ -f nodejs-mac-x64/bin/node ]; then
+  echo "Downloading NodeJS LTS (x64)"
+  curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-x64.tar.gz     
+  mkdir nodejs-mac-x64
+  tar -xzf nodejs-mac-x64.tar.gz -C nodejs-mac-x64 --strip-components=1 && rm ./nodejs-mac-x64.tar.gz
+  rm node-*-darwin-x64.tar.gz
+fi
+
+export CORRETTO_BASEDIR="$HOME/Library/Application Support/Purple HATS"
+mkdir -p "$CORRETTO_BASEDIR" 
+
+echo "INFO: Set path to Corretto-11 JDK"
+export JAVA_HOME="$CORRETTO_BASEDIR/amazon-corretto-11.jdk.x64/Contents/Home"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+if ! [ -f jre/bin/java ]; then
+  cd "$CORRETTO_BASEDIR" 
+  if ! [ -f amazon-corretto-11.jdk.x64/Contents/Home/bin/java ]; then
+      echo "Downloading Corretto (x64)"
+      curl -L -o ./corretto-11.tar.gz "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz"
+      tar -zxf ./corretto-11.tar.gz
+      rm -f ./corretto-11.tar.gz
+      mv amazon-corretto-11.jdk amazon-corretto-11.jdk.x64
+  else
+    echo "Found Corretto (x64)"
   fi
 
-  if ! [ -f nodejs-mac-x64/bin/node ]; then
-    echo "Downloading NodeJS LTS (x64)"
-    curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v18.18.0/node-v18.18.0-darwin-x64.tar.gz     
-    mkdir nodejs-mac-x64 && tar -xzf nodejs-mac-x64.tar.gz -C nodejs-mac-x64 --strip-components=1 && rm ./nodejs-mac-x64.tar.gz
-    rm node-*-darwin-x64.tar.gz
-  fi
-
-  export CORRETTO_BASEDIR="$HOME/Library/Application Support/Purple HATS"
-  mkdir -p "$CORRETTO_BASEDIR" 
-
-  if ! [ -f jre/bin/java ]; then
-    cd "$CORRETTO_BASEDIR" 
-    if ! [ -f amazon-corretto-11.jdk.x64/Contents/Home/bin/java ]; then
-        echo "Downloading Corretto (x64)"
-        curl -L -o ./corretto-11.tar.gz "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz"
-        tar -zxf ./corretto-11.tar.gz
-        rm -f ./corretto-11.tar.gz
-        mv amazon-corretto-11.jdk amazon-corretto-11.jdk.x64
-    else
-      echo "Found Corretto (x64)"
-    fi
-
-    echo "INFO: Set path to Corretto-11 JDK"
-    export JAVA_HOME="$CORRETTO_BASEDIR/amazon-corretto-11.jdk.x64/Contents/Home"
-    export PATH="$JAVA_HOME/bin:$PATH"
-
-    echo "INFO: Build JRE SE"
-    cd "$__dir"
-    jlink --output jre --add-modules java.se
-
-  fi
-
-  if ! [ -f verapdf/verapdf ]; then
-    echo "Downloading VeraPDF"
-    if [ -d "./verapdf" ]; then rm -Rf ./verapdf; fi
-    if [ -d "./verapdf-installer" ]; then rm -Rf ./verapdf-installer; fi
-    curl -L -o ./verapdf-installer.zip http://downloads.verapdf.org/rel/verapdf-installer.zip
-    unzip -j ./verapdf-installer.zip -d ./verapdf-installer
-    ./verapdf-installer/verapdf-install "${__dir}/verapdf-auto-install-macos.xml"
-    cp -r /tmp/verapdf .
-    rm -rf ./verapdf-installer.zip ./verapdf-installer /tmp/verapdf
-    
-  fi
-
-  if [ -d "/Applications/Cloudflare WARP.app" ]; then
-    curl -sSLJ -o "/tmp/Cloudflare_CA.pem" "https://developers.cloudflare.com/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem"
-    export NODE_EXTRA_CA_CERTS="/tmp/Cloudflare_CA.pem"
-  fi
-
-  if ! [ -f package.json ] && [ -d purple-hats ]; then
-    cd purple-hats
-  fi
-
-  if [ -d "node_modules" ]; then
-    echo "Deleting node_modules before installation"
-    rm -rf node_modules 
-  fi
-
-  echo "Installing Node dependencies to $PWD and Installing Playwright browsers"
-  "${__dir}/hats_shell.sh" 'npm ci --force; npx playwright install webkit;'
+  echo "INFO: Build JRE SE"
+  cd "$__dir"
+  jlink --output jre --add-modules java.se
 
 fi
+
+if ! [ -f verapdf/verapdf ]; then
+  echo "Downloading VeraPDF"
+  if [ -d "./verapdf" ]; then rm -Rf ./verapdf; fi
+  if [ -d "./verapdf-installer" ]; then rm -Rf ./verapdf-installer; fi
+  curl -L -o ./verapdf-installer.zip http://downloads.verapdf.org/rel/verapdf-installer.zip
+  unzip -j ./verapdf-installer.zip -d ./verapdf-installer
+  ./verapdf-installer/verapdf-install "${__dir}/verapdf-auto-install-macos.xml"
+  cp -r /tmp/verapdf .
+  rm -rf ./verapdf-installer.zip ./verapdf-installer /tmp/verapdf
+  
+fi
+
+if [ -d "/Applications/Cloudflare WARP.app" ]; then
+  curl -sSLJ -o "/tmp/Cloudflare_CA.pem" "https://developers.cloudflare.com/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem"
+  export NODE_EXTRA_CA_CERTS="/tmp/Cloudflare_CA.pem"
+fi
+
+source "${__dir}/hats_shell.sh"
+
+if ! [ -f package.json ] && [ -d purple-hats ]; then
+  cd purple-hats
+fi
+
+if [ -d "node_modules" ]; then
+  echo "Deleting node_modules before installation"
+  rm -rf node_modules 
+fi
+
+echo "Installing Node dependencies to $PWD"
+npm ci


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Removes screenshot PDF document due to difficulty compiling node-canvas on M1 (arm64) Mac
- Switch browser from Webkit to Chrome for running Custom flow on MacOS

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
