### PR TITLE
Support file upload event for custom flow scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ verapdf*
 ms-playwright/
 a11y-scan-results*.zip
 PHScan_*/
+Upload Files/
 
 # match YYYYMMDD_HHMMSS_* pattern for dataset files
 [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]_*/

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -697,6 +697,10 @@ const clickFunc = async (elem,page) => {
               const finalFilename = getStringWithinSingleQuotes(trimmedArg);
               substitutedArgument = `"${path.join(__dir, finalFilename)}"`;
             }
+            if (os.platform() === 'win32') {
+              // escape backslashes if on windows
+              substitutedArgument = substitutedArgument.replaceAll("\\", "\\\\");
+            }
             return `.setInputFiles(${substitutedArgument})`;
           });
           return modifiedCode;

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -572,6 +572,8 @@ const clickFunc = async (elem,page) => {
         } else {
           appendToGeneratedScript(line);
         }
+        // to dismiss file explorer window popups
+        appendToGeneratedScript("page.on('filechooser', () => {});");
         continue;
       }
 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Append the user's export directory to arguments of setInputFiles() so that playwright can find the uploaded files 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
