### PR TITLE
Add -q flag for additional scan metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Options:
                     none - Exclude all additional features in the generated re
                     port
               [string] [choices: "screenshots", "none"] [default: "screenshots"]
-  -q, --metadata  Json string that contains additional scan metadata.
+  -q, --metadata  Json string that contains additional scan metadata for
+                  telemetry purposes.
                   Defaults to "{}"
                                                         [string] [default: "{}"]
 Examples:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,10 @@ Options:
                     report
                     none - Exclude all additional features in the generated re
                     port
-            [string] [choices: "screenshots", "none"] [default: "screenshots"]
+              [string] [choices: "screenshots", "none"] [default: "screenshots"]
+  -q, --metadata  Json string that contains additional scan metadata.
+                  Defaults to "{}"
+                                                        [string] [default: "{}"]
 Examples:
   To scan sitemap of website:', 'node cli.js -c [ 1 | Sitemap ] -d <device> -u
    <url_link> -w <viewportWidth>

--- a/cli.js
+++ b/cli.js
@@ -232,7 +232,6 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
       // default to empty object
       return "{}";
     }
-    console.log(option, "OPTION");
     return option;
   })
   .check(argvs => {

--- a/cli.js
+++ b/cli.js
@@ -225,6 +225,16 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     }
     return option;
   })
+  .coerce('q', option => {
+    try {
+      JSON.parse(option);
+    } catch (e) {
+      // default to empty object
+      return "{}";
+    }
+    console.log(option, "OPTION");
+    return option;
+  })
   .check(argvs => {
     if (argvs.scanner === 'custom' && argvs.maxpages) {
       throw new Error('-p or --maxpages is only available in website and sitemap scans.');

--- a/combine.js
+++ b/combine.js
@@ -29,6 +29,7 @@ const combineRun = async (details, deviceToScan) => {
     fileTypes,
     blacklistedPatternsFilename,
     includeScreenshots,
+    metadata,
   } = envDetails;
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
@@ -125,16 +126,17 @@ const combineRun = async (details, deviceToScan) => {
       browser
     );
     const [name, email] = nameEmail.split(':');
-    // await submitForm(
-    //   browser,
-    //   userDataDirectory,
-    //   url,
-    //   type,
-    //   email,
-    //   name,
-    //   JSON.stringify(basicFormHTMLSnippet),
-    //   urlsCrawled.scanned.length,
-    // );
+    await submitForm(
+      browser,
+      userDataDirectory,
+      url,
+      type,
+      email,
+      name,
+      JSON.stringify(basicFormHTMLSnippet),
+      urlsCrawled.scanned.length,
+      metadata,
+    );
   } else {
     printMessage([`No pages were scanned.`], constants.alertMessageOptions);
   }

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -133,6 +133,13 @@ export const cliOptions = {
     choices: ['screenshots', 'none'],
     requiresArg: true,
     demandOption: false,
+  },
+  q: {
+    alias: 'metadata',
+    describe: 'Additional scan metadata',
+    type: 'string',
+    default: '{}',
+    demandOption: false,
   }
 };
 

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -136,7 +136,7 @@ export const cliOptions = {
   },
   q: {
     alias: 'metadata',
-    describe: 'Json string that constains additional scan metadata. Defaults to "{}"',
+    describe: 'Json string that contains additional scan metadata. Defaults to "{}"',
     type: 'string',
     default: '{}',
     demandOption: false,

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -136,7 +136,7 @@ export const cliOptions = {
   },
   q: {
     alias: 'metadata',
-    describe: 'Additional scan metadata',
+    describe: 'Json string that constains additional scan metadata. Defaults to "{}"',
     type: 'string',
     default: '{}',
     demandOption: false,

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -136,7 +136,7 @@ export const cliOptions = {
   },
   q: {
     alias: 'metadata',
-    describe: 'Json string that contains additional scan metadata. Defaults to "{}"',
+    describe: 'Json string that contains additional scan metadata for telemetry purposes. Defaults to "{}"',
     type: 'string',
     default: '{}',
     demandOption: false,

--- a/constants/common.js
+++ b/constants/common.js
@@ -473,6 +473,7 @@ export const prepareData = argv => {
     fileTypes,
     blacklistedPatternsFilename,
     additional,
+    metadata
   } = argv;
 
   // construct filename for scan results
@@ -501,6 +502,7 @@ export const prepareData = argv => {
     fileTypes,
     blacklistedPatternsFilename,
     includeScreenshots: !(additional === 'none'),
+    metadata,
   };
 };
 
@@ -1192,6 +1194,7 @@ export const submitForm = async (
   name,
   scanResultsJson,
   numberOfPagesScanned,
+  metadata,
 ) => {
   const finalUrl =
     `${formDataFields.formUrl}?` +
@@ -1200,7 +1203,8 @@ export const submitForm = async (
     `${formDataFields.emailField}=${email}&` +
     `${formDataFields.nameField}=${name}&` +
     `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
-    `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}`;
+    `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
+    `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
 
   if (proxy) {
     await submitFormViaPlaywright(browserToRun, userDataDirectory, finalUrl);

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -236,6 +236,7 @@ export const formDataFields = {
   nameField: 'entry.1787318910',
   resultsField: 'entry.904051439',
   numberOfPagesScannedField: 'entry.238043773',
+  metadataField: 'entry.1027769131',
 };
 
 const urlCheckStatuses = {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ const runScan = async (answers) => {
   answers.browserToRun = browserToRun; 
   answers.nameEmail = `${userData.name}:${userData.email}`;
   answers.fileTypes = 'html-only';
+  answers.metadata = "{}";
   
   const data = prepareData(answers);
   clonedDataDir = getClonedProfilesWithRandomToken(data.browser, data.randomToken); 

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -107,6 +107,7 @@ export const init = async (entryUrl, customFlowLabelTestString, name = "Your Nam
         name,
         JSON.stringify(basicFormHTMLSnippet),
         urlsCrawled.scanned.length,
+        "{}",
       )
 
     }

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -368,6 +368,7 @@ const clickFunc = async (elem,page, clickOptions=undefined) => {
     ${formatScriptStringVar(data.nameEmail.split(':')[0])},
     JSON.stringify(basicFormHTMLSnippet),
     urlsCrawled.scanned.length,
+    "${data.metadata.replace(/"/g, '\\"')}",
   );
 
   if (process.env.RUNNING_FROM_PH_GUI) {

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -301,7 +301,6 @@ const clickFunc = async (elem,page, clickOptions=undefined) => {
 
           if (await waitForElemIsVisible(nth, 500)) {
             await processPage(page);
-            // await nth.click(clickOptions);
             await clickElem(nth);
             return;
           }
@@ -315,7 +314,6 @@ const clickFunc = async (elem,page, clickOptions=undefined) => {
     await hoverParentAndClickElem(elem, page);
   
   } else if (numElems === 0) {
-      // await elem.click();
       await clickElem(elem);
 
   } else for (let index = numElems - 1; index >= 0; index--) {
@@ -323,7 +321,6 @@ const clickFunc = async (elem,page, clickOptions=undefined) => {
       if (! await nth.isVisible()) {
         await hoverParentAndClickElem(nth, page);
       } else {
-        // await nth.click();
         await clickElem(nth);
       }
   }


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- New `-q` flag to specify additional scan metadata as a json string for submission to the scan results form

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
