### PR TITLE
Fix screenshot timeout and omit crawler enqueueLinks clicks on iframe

### DIFF
--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -95,10 +95,11 @@ const crawlDomain = async (
 
     await enqueueLinksByClickingElements({
       // set selector matches
+      // NOT <iframe>
       // NOT <a>
       // IS role='link' or button onclick
       // enqueue new page URL
-      selector: ':not(a):is(*[role="link"], button[onclick])',
+      selector: ':not(iframe), :not(a):is(*[role="link"], button[onclick])',
       transformRequestFunction(req) {
         req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
         if (isUrlPdf(req.url)) {

--- a/screenshotFunc/htmlScreenshotFunc.js
+++ b/screenshotFunc/htmlScreenshotFunc.js
@@ -3,6 +3,7 @@ import { silentLogger } from '../logs.js';
 
 export const takeScreenshotForHTMLElements = async (violations, page, randomToken) => {
     let newViolations = [];
+    const locatorTimeout = 5000;
     for (const violation of violations) {
         const { id: rule } = violation; 
         let newViolationNodes = [];
@@ -14,11 +15,11 @@ export const takeScreenshotForHTMLElements = async (violations, page, randomToke
                 try {
                     const screenshotPath = generateScreenshotPath(page.url(), impact, rule, newViolationNodes.length);
                     const locator = page.locator(selector);
-                    await locator.scrollIntoViewIfNeeded();
-                    await locator.screenshot({ path: `${randomToken}/${screenshotPath}` });
+                    await locator.scrollIntoViewIfNeeded({ timeout: locatorTimeout });
+                    await locator.screenshot({ path: `${randomToken}/${screenshotPath}`, timeout: locatorTimeout });
                     node.screenshotPath = screenshotPath; 
                 } catch (e) {
-                    silentLogger.error(e);
+                    silentLogger.info(e);
                 }
             }
             newViolationNodes.push(node);


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Fix rare occurrence that element to be screenshot disappear from viewport
- Fix rare occurrence that an iframe causes PlaywrightCrawler enqueueLinks to crash

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
