### PR TITLE
Remove rosetta2 installation scripts and instructions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -126,7 +126,4 @@ username@hostname purple-hats % node index
 ```
 
  * Follow the steps at [Features](https://github.com/GovTechSG/purple-hats#features) for more information on how to run a scan.
- 
- * If you are running on an Apple Silicon Mac, you may be prompted to install [Rosetta 2](https://support.apple.com/en-sg/HT211861).  Click "Install" and try running Purple hats again.
- <img width="360" alt="Rosetta 2 alert prompt" src="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macos/Big-Sur/macos-big-sur-software-update-rosetta-alert.jpg">
 </details>

--- a/scripts/hats_shell.sh
+++ b/scripts/hats_shell.sh
@@ -19,12 +19,6 @@ SHELL_COMMAND=$(ps -o comm= -p $$)
 SHELL_NAME="${SHELL_COMMAND#-}"
 
 if [[ $(uname -m) == 'arm64' ]]; then
-    export ROSETTA2_STATUS_RESULT=$(/usr/bin/pgrep -q oahd && echo true || echo false)
-    if ! $ROSETTA2_STATUS_RESULT; then   
-        echo "Installing Rosetta 2 dependency"
-        /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-    fi
-
     echo "INFO: Setting path to node arm64 for this session"
     export PATH_TO_NODE="$PWD/nodejs-mac-arm64/bin"
 

--- a/scripts/install_purple_dependencies.command
+++ b/scripts/install_purple_dependencies.command
@@ -15,15 +15,6 @@ if [ "$CURR_FOLDERNAME" = "scripts" ]; then
   CURR_FOLDERNAME="$(basename "$PWD")"
 fi
 
-if [[ $(uname -m) == 'arm64' ]]; then
-    export ROSETTA2_STATUS_RESULT=$(/usr/bin/pgrep -q oahd && echo true || echo false)
-    if ! $ROSETTA2_STATUS_RESULT; then   
-        echo "Installing Rosetta 2 dependency"
-        /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-    fi
-
-fi
-
 if ! [ -f nodejs-mac-arm64/bin/node ]; then
   echo "Downloading NodeJS LTS (ARM64)"
   curl -o ./nodejs-mac-arm64.tar.gz --create-dirs https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-arm64.tar.gz  


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Removes rosetta2 dependency for M1 macs

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
