### PR TITLE
Sign binaries for macos

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -48,6 +48,11 @@ jobs:
     environment: macos
     
     steps:
+      - name: Clean Workspace Folder
+        run: |
+         rm -rf ./* || true
+         rm -rf ./.??* || true
+         
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -44,8 +44,9 @@ jobs:
             purple-hats-portable-windows.zip
             
   mac-install-purple:
-    runs-on: macos-latest  
-
+    runs-on: self-hosted
+    environment: macos
+    
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -64,6 +65,27 @@ jobs:
         run: |
           ./install_purple_dependencies.command
 
+      - name: Sign required binaries for MacOS
+        run: |
+          # Find a valid signing certificate in your keychain
+          CERTIFICATE=$(security find-identity -v -p codesigning -s - | tail -n +2 | grep -o '"[^"]*"' | sed 's/"//g')
+          
+          # Paths to the binaries you want to sign
+          BINARIES=(
+            "./purple-hats/node_modules/playwright/node_modules/fsevents/fsevents.node"
+            "./purple-hats/node_modules/fsevents/fsevents.node"
+          )
+
+          # Loop through the binary paths and sign each one with a secure timestamp
+          for binary in "${BINARIES[@]}"; do
+            codesign --timestamp -s "$CERTIFICATE" "$binary"
+            if [ $? -eq 0 ]; then
+              echo "Successfully signed (with secure timestamp): $binary"
+            else
+              echo "Failed to sign: $binary"
+            fi
+          done
+        
       - name: Zip entire Purple folder (Mac)
         run: |
           zip purple-hats-portable-mac.zip -y -r ./


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- Signing

  ```
  "./purple-hats/node_modules/playwright/node_modules/fsevents/fsevents.node"
  "./purple-hats/node_modules/fsevents/fsevents.node"
  ```
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
