### PR TITLE
extend timeout for custom page.goto and fix element screenshot

### DIFF
--- a/crawlers/runCustom.js
+++ b/crawlers/runCustom.js
@@ -60,7 +60,7 @@ const runCustom = async (
     });
 
     const page = await context.newPage();
-    await page.goto(url);
+    await page.goto(url, { timeout: 0 });
 
     // to execute and wait for all pages to close
     // idea is for promise to be pending until page.on('close') detected

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -737,7 +737,7 @@ const waitForCaptcha = async (page, captchaLocator) => {
       }
       if (lastGoToUrl) {
         appendToGeneratedScript(`
-          await ${pageObj}.waitForURL('${lastGoToUrl}',{timeout: 60000});
+          await ${pageObj}.waitForURL(${formatScriptStringVar(lastGoToUrl)},{ timeout: 0 });
           await processPage(page);
         `);
 
@@ -756,8 +756,7 @@ const waitForCaptcha = async (page, captchaLocator) => {
           firstGoToUrl = true;
           const firstGoToAddress = line.split(`('`)[1].split(`')`)[0];
           appendToGeneratedScript(
-            `${line}
-            `,
+            `await page.goto(${formatScriptStringVar(firstGoToAddress)}, { timeout: 0 });`,
           );
           lastGoToUrl = firstGoToAddress;
           continue;

--- a/screenshotFunc/htmlScreenshotFunc.js
+++ b/screenshotFunc/htmlScreenshotFunc.js
@@ -1,9 +1,8 @@
 // import { JSDOM } from "jsdom";
 import { silentLogger } from '../logs.js';
 
-export const takeScreenshotForHTMLElements = async (violations, page, randomToken) => {
+export const takeScreenshotForHTMLElements = async (violations, page, randomToken, locatorTimeout = 2000) => {
     let newViolations = [];
-    const locatorTimeout = 5000;
     for (const violation of violations) {
         const { id: rule } = violation; 
         let newViolationNodes = [];
@@ -15,6 +14,8 @@ export const takeScreenshotForHTMLElements = async (violations, page, randomToke
                 try {
                     const screenshotPath = generateScreenshotPath(page.url(), impact, rule, newViolationNodes.length);
                     const locator = page.locator(selector);
+                    // catch uncommon cases where components are not found in screenshot line
+                    await locator.waitFor('visible', { timeout: locatorTimeout});
                     await locator.scrollIntoViewIfNeeded({ timeout: locatorTimeout });
                     await locator.screenshot({ path: `${randomToken}/${screenshotPath}`, timeout: locatorTimeout });
                     node.screenshotPath = screenshotPath; 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

* extend custom flow timeout for page goto
* add visible state catch for element screenshot

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
