### PR TITLE
Fix bug for retrieving url from meta tags 

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -274,8 +274,7 @@ const requestToUrl = async url => {
       } else {
         res.url = url;
       }
-      console.log(response);
-
+      
       let modifiedHTML = response.data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
       const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?([^"]*)"/i.exec(modifiedHTML);
       if (metaRefreshMatch && metaRefreshMatch[1]) {

--- a/constants/common.js
+++ b/constants/common.js
@@ -274,10 +274,10 @@ const requestToUrl = async url => {
       } else {
         res.url = url;
       }
+      console.log(response);
 
-      const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?([^"]*)"/i.exec(
-        response.data,
-      );
+      let modifiedHTML = response.data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
+      const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?([^"]*)"/i.exec(modifiedHTML);
       if (metaRefreshMatch && metaRefreshMatch[1]) {
         const urlOrRelativePath = metaRefreshMatch[1];
         if (urlOrRelativePath.includes('URL=')) {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Remove noscript tags from response data before extracting URLs from meta tag

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
